### PR TITLE
Expand adversarial pressure-pass framework for crit sessions

### DIFF
--- a/MASTER2/lib/pressure_pass.rb
+++ b/MASTER2/lib/pressure_pass.rb
@@ -10,6 +10,29 @@ module MASTER
   module PressurePass
     module_function
 
+    CRIT_SESSION_PANEL = [
+      {
+        role: "adversarial architect",
+        ask: "Where does the structure collapse under scale, constraints, or maintenance debt?",
+      },
+      {
+        role: "adversarial web designer",
+        ask: "Where does interaction clarity fail for real users, especially under stress?",
+      },
+      {
+        role: "adversarial electronic musician",
+        ask: "Where does rhythm, variation, and emotional pacing become repetitive or dead?",
+      },
+      {
+        role: "adversarial indie filmmaker",
+        ask: "Where does the narrative lose coherence, tension, or visual intent?",
+      },
+      {
+        role: "adversarial slam poet",
+        ask: "Where does language lose impact, authenticity, or memorable cadence?",
+      },
+    ].freeze
+
     def enabled?
       val = ENV.fetch("MASTER_PRESSURE_PASS", "false").to_s.strip.downcase
       !%w[0 false off no].include?(val)
@@ -32,6 +55,8 @@ module MASTER
     end
 
     def prompt(user_input, candidate_text)
+      panel = CRIT_SESSION_PANEL.map { |p| "- #{p[:role]}: #{p[:ask]}" }.join("\n")
+
       <<~PROMPT
         You are an adversarial reviewer. Treat this as hostile scrutiny.
         The goal is stronger truthfulness and utility, not aggression for its own sake.
@@ -42,13 +67,18 @@ module MASTER
         Candidate answer:
         #{candidate_text.to_s[0, 6000]}
 
+        Crit session framework (run all lenses):
+        #{panel}
+
         Perform serial pressure testing:
         1) Strongest counterargument against the candidate answer.
         2) Concrete failure modes or risks.
         3) Produce at least 2 improved alternative answers.
-        4) Choose the best one and explain why.
+        4) Cherry-pick the strongest parts across alternatives into one final answer.
+        5) Explain why the cherry-picked final answer wins.
 
         Constraints:
+        - Ask adversarial questions before proposing alternatives.
         - Keep alternatives concise and actionable.
         - No markdown fences.
         - selected_answer must be the final answer to return to the user.

--- a/MASTER2/test/test_pressure_pass.rb
+++ b/MASTER2/test/test_pressure_pass.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestPressurePass < Minitest::Test
+  def test_prompt_includes_full_crit_session_panel
+    prompt = MASTER::PressurePass.prompt("Improve this answer", "Candidate")
+
+    assert_includes prompt, "adversarial architect"
+    assert_includes prompt, "adversarial web designer"
+    assert_includes prompt, "adversarial electronic musician"
+    assert_includes prompt, "adversarial indie filmmaker"
+    assert_includes prompt, "adversarial slam poet"
+  end
+
+  def test_prompt_enforces_cherry_picked_multi_solution_selection
+    prompt = MASTER::PressurePass.prompt("Request", "Candidate")
+
+    assert_includes prompt, "Cherry-pick the strongest parts across alternatives"
+    assert_includes prompt, "Ask adversarial questions before proposing alternatives"
+  end
+end


### PR DESCRIPTION
### Motivation
- Improve the adversarial pressure-pass to force deeper, multidisciplinary critique and multi-solution reasoning before returning a final answer.
- Surface failure modes from creative and interaction-focused lenses (architecture, web UX, musical pacing, film, and poetic language) so the pressure-pass yields more robust and usable outputs.

### Description
- Add a `CRIT_SESSION_PANEL` constant listing five adversarial lenses with focused questions for each: architect, web designer, electronic musician, indie filmmaker, and slam poet, in `MASTER2/lib/pressure_pass.rb`.
- Extend `PressurePass.prompt` to render the crit-session panel, require adversarial questioning prior to alternatives, and change the selection step to "cherry-pick the strongest parts across alternatives into one final answer" with an explanation.
- Add unit tests in `MASTER2/test/test_pressure_pass.rb` that assert the prompt includes each panel member and the new cherry-pick / adversarial-questioning constraints.

### Testing
- Performed static syntax checks with `ruby -c MASTER2/lib/pressure_pass.rb` and `ruby -c MASTER2/test/test_pressure_pass.rb`, both of which returned `Syntax OK`.
- Attempted to run the unit tests via `ruby -Itest test/test_pressure_pass.rb` but the runtime test run could not complete in this environment due to a missing `ruby_llm` dependency required by `lib/master.rb` (blocking full execution of the test harness).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11404fc3c832aaa5f04724cfaa523)