### PR TITLE
Fix OpenBSD deploy script to run directly and skip repeat execution

### DIFF
--- a/MASTER3/DEPLOY/openbsd/openbsd.sh
+++ b/MASTER3/DEPLOY/openbsd/openbsd.sh
@@ -1,4 +1,3 @@
-```ksh
 #!/bin/ksh
 # Configures OpenBSD 7.8 for NSD & DNSSEC, Ruby on Rails, PF firewall, and minimal OpenSMTPD.
 
@@ -164,6 +163,11 @@ configure_rails() {
 
 # Main execution
 main() {
+    if is_step_completed "setup_completed"; then
+        log INFO "Setup already completed. Nothing to do."
+        return 0
+    fi
+
     # Handle command line arguments
     if [ $# -gt 0 ]; then
         handle_resume "$1" || true
@@ -181,8 +185,8 @@ main() {
     configure_smtpd
     configure_rails
 
+    mark_step_completed "setup_completed"
     log INFO "Configuration completed successfully"
 }
 
 main "$@"
-```


### PR DESCRIPTION
## Summary
- Removed markdown code fences from `MASTER3/DEPLOY/openbsd/openbsd.sh` so it executes as a real `ksh` script.
- Added a one-time execution guard in `main()` that exits early when `setup_completed` is already recorded.
- Marked successful completion by writing `setup_completed` at the end of a full successful run.

## Why
The script was wrapped in markdown fences, which broke direct execution. Also, rerunning after a successful setup should be a no-op for safer idempotent operations.

## Validation
- Reviewed the resulting diff to confirm only `openbsd.sh` changed.
- Confirmed commit was created on current branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b116f0aed4832a804549e575c7d46f)