### PR TITLE
Add deep exec-flow tests for MASTER2 and MASTER3

### DIFF
--- a/MASTER2/test/test_exec_flow_deep_traces.rb
+++ b/MASTER2/test/test_exec_flow_deep_traces.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestExecFlowDeepTraces < Minitest::Test
+  def setup
+    setup_db
+  end
+
+  def teardown
+    teardown_db
+  end
+
+  def test_executor_flow_enriches_lint_trace_and_security_veto
+    executor_result = MASTER::Result.ok(
+      response: "done",
+      steps: [
+        { tool: "council_review", result: "security REJECT due to unsafe auth path" }
+      ]
+    )
+
+    lint_stage = Object.new
+    def lint_stage.call(_input)
+      MASTER::Result.ok(axiom_violations: ["ONE_SOURCE"], zsh_violations: ["sudo"])
+    end
+
+    MASTER::Executor.stub(:call, executor_result) do
+      MASTER::Stages::Lint.stub(:new, lint_stage) do
+        result = MASTER::Pipeline.new(mode: :executor).call(text: "safe input")
+
+        assert result.ok?, result.error
+        assert_equal ["ONE_SOURCE"], result.value[:axiom_violations]
+        assert_equal ["sudo"], result.value[:zsh_violations]
+        assert_equal true, result.value[:council_security_veto]
+      end
+    end
+  end
+
+  def test_executor_error_short_circuits_before_lint
+    lint_stage = Object.new
+    def lint_stage.call(_input)
+      raise "lint should not run"
+    end
+
+    MASTER::Executor.stub(:call, MASTER::Result.err("boom", category: :infrastructure)) do
+      MASTER::Stages::Lint.stub(:new, lint_stage) do
+        result = MASTER::Pipeline.new(mode: :executor).call(text: "safe input")
+
+        assert result.err?
+        assert_equal "boom", result.error
+      end
+    end
+  end
+
+  def test_normalize_result_strips_tool_blocks_for_clean_ux
+    raw = MASTER::Result.ok(
+      response: <<~TEXT
+        Here is what I did:
+
+        ```sh
+        file_read "lib/a.rb"
+        ```
+
+        Final answer visible to user.
+      TEXT
+    )
+
+    result = MASTER::Pipeline.new(mode: :executor).normalize_result(raw, "prompt")
+
+    assert result.ok?
+    assert_includes result.value[:rendered], "Final answer visible to user."
+    refute_includes result.value[:rendered], "file_read"
+  end
+end

--- a/MASTER3/test/test_exec_flow_deep_traces.rb
+++ b/MASTER3/test/test_exec_flow_deep_traces.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestMaster3ExecFlowDeepTraces < Minitest::Test
+  DummyConfig = Struct.new(:auto_testing?)
+
+  class PassGuard
+    def scan(_msg) = Master3::Result.ok(:clear)
+  end
+
+  class PlainRenderer
+    def render(text, mode: :plain) = "[#{mode}] #{text}"
+  end
+
+  def build_pipeline(event_bus: nil)
+    commands = {
+      "trace" => lambda { |ctx|
+        event_bus&.publish("exec:trace", command: ctx[:command], args: ctx[:args])
+        "Certainly. I think that trace complete. I hope this helps."
+      }
+    }
+
+    stages = [
+      Master3::Stages::Intake.new,
+      Master3::Stages::Route.new(commands:, agent: ->(_ctx) { "agent reply" }),
+      Master3::Stages::Guard.new(governor: Object.new, injection_guard: PassGuard.new),
+      Master3::Stages::Execute.new,
+      Master3::Stages::Strunk.new,
+      Master3::Stages::Render.new(renderer: PlainRenderer.new)
+    ]
+
+    Master3::Pipeline.new(stages)
+  end
+
+  def test_command_execution_flow_emits_trace_and_cleans_output
+    ring = Master3::RingBuffer.new(20)
+    bus = Master3::EventBus.new(log: ring)
+    logging = Master3::Logging.new(ring_buffer: ring, event_bus: bus)
+    pipeline = build_pipeline(event_bus: bus)
+
+    result = pipeline.call(Master3::Result.ok(user_message: "/trace --deep"))
+
+    assert result.ok?
+    rendered = result.value[:rendered]
+    assert_includes rendered, "trace complete."
+    refute_includes rendered, "Certainly."
+    refute_includes rendered, "I think that"
+
+    entries = []
+    ring.each { |line| entries << line }
+    dmesg = entries.join("\n")
+    assert_includes dmesg, "exec:trace"
+    assert_includes dmesg, "--deep"
+  end
+
+  def test_unknown_command_is_validation_error_edge_case
+    pipeline = build_pipeline
+
+    result = pipeline.call(Master3::Result.ok(user_message: "/missing"))
+
+    assert result.err?
+    assert_equal :validation, result.category
+    assert_match %r{unknown command: /missing}, result.message
+  end
+
+  def test_execute_stage_survives_handler_exceptions
+    execute = Master3::Stages::Execute.new
+
+    result = execute.call(handler: ->(_ctx) { raise "kaboom" })
+
+    assert result.err?
+    assert_equal :unknown, result.category
+    assert_match(/execute: kaboom/, result.message)
+  end
+end

--- a/MASTER3/test/test_helper.rb
+++ b/MASTER3/test/test_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+
+require_relative "../lib/master3/result"
+require_relative "../lib/master3/pipeline"
+require_relative "../lib/master3/ring_buffer"
+require_relative "../lib/master3/event_bus"
+require_relative "../lib/master3/logging"
+require_relative "../lib/master3/stages/intake"
+require_relative "../lib/master3/stages/route"
+require_relative "../lib/master3/stages/guard"
+require_relative "../lib/master3/stages/execute"
+require_relative "../lib/master3/stages/strunk"
+require_relative "../lib/master3/stages/render"


### PR DESCRIPTION
### Motivation
- Improve automated coverage around executor/pipeline execution flows to catch trace enrichment, UX normalization, and edge-case behavior. 
- Ensure both legacy `MASTER2` executor-mode paths and the staged `MASTER3` pipeline command flow behave correctly under linting, security veto, and handler-error conditions. 

### Description
- Added `MASTER2/test/test_exec_flow_deep_traces.rb` to exercise executor-mode normalization, lint enrichment, council security veto detection, and error short-circuiting. 
- Added `MASTER3/test/test_helper.rb` as a lightweight harness that requires core `master3` components for focused testing. 
- Added `MASTER3/test/test_exec_flow_deep_traces.rb` to simulate the Intake → Route → Guard → Execute → Strunk → Render command path, assert EventBus trace emission via the ring buffer, and verify unknown-command and execute-handler exception behavior. 

### Testing
- Ran `ruby -I MASTER3/test MASTER3/test/test_exec_flow_deep_traces.rb` and the `MASTER3` tests passed (3 runs, 19 assertions, 0 failures, 0 errors). 
- Performed syntax checks with `ruby -c` on the new tests and helper and they returned `Syntax OK`. 
- Attempted to run `ruby -I MASTER2/test MASTER2/test/test_exec_flow_deep_traces.rb` but it was blocked in this environment due to missing runtime gem dependencies (e.g. `ruby_llm` / `tty-reader`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b117ca9f8c832a8e94b703abc23748)