### PR TITLE
Upgrade MASTER2 selfrun pipeline to full-scan orchestrated workflow

### DIFF
--- a/__predecessors/MASTER2/lib/auto_fixer.rb
+++ b/__predecessors/MASTER2/lib/auto_fixer.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module MASTER
+  # AutoFixer - safe wrapper around optional external auto-fix engines.
+  # If no external AutoFixer is installed, this class provides a predictable
+  # fallback API so commands/tests can still run in read/analyze environments.
+  class AutoFixer
+    attr_reader :mode
+
+    def initialize(mode: :moderate)
+      @mode = mode
+      @history = []
+    end
+
+    def fix(path = nil, issue: nil, **opts)
+      if external_fixer_available?
+        external_fixer.new(mode: mode).fix(path, issue: issue, **opts)
+      else
+        @history << { at: Time.now.utc.iso8601, path: path, issue: issue, mode: mode, opts: opts }
+        Result.ok(fixed: false, reason: "No external AutoFixer installed", mode: mode, path: path)
+      end
+    rescue StandardError => e
+      Result.err("AutoFixer failed: #{e.message}")
+    end
+
+    def rollback(*args, **kwargs)
+      if external_fixer_available? && external_fixer.instance_methods.include?(:rollback)
+        external_fixer.new(mode: mode).rollback(*args, **kwargs)
+      else
+        last = @history.pop
+        Result.ok(rolled_back: !last.nil?, mode: mode, last: last)
+      end
+    rescue StandardError => e
+      Result.err("AutoFixer rollback failed: #{e.message}")
+    end
+
+    private
+
+    def external_fixer_available?
+      external_fixer && external_fixer != self.class
+    end
+
+    def external_fixer
+      @external_fixer ||= begin
+        klass = Object.const_get(:AutoFixer) if Object.const_defined?(:AutoFixer)
+        klass if klass.is_a?(Class)
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/__predecessors/MASTER2/lib/evolve.rb
+++ b/__predecessors/MASTER2/lib/evolve.rb
@@ -14,12 +14,13 @@ module MASTER
     CONVERGENCE_THRESHOLD = 0.02
     PER_FILE_BUDGET = 0.25
 
-    def initialize(llm: LLM, chamber: nil, staged: false, validation_command: nil, language: :ruby)
+    def initialize(llm: LLM, chamber: nil, staged: false, validation_command: nil, language: :ruby, max_retries: 1)
       @llm = llm
       @chamber = chamber || Council.new(llm: llm)
       @staged = staged
       @validation_command = validation_command
       @language = language
+      @max_retries = [max_retries.to_i, 0].max
       @iteration = 0
       @cost = 0.0
       @history = []
@@ -28,6 +29,8 @@ module MASTER
     def run(path: MASTER.root, dry_run: true)
       Logging.dmesg_log("evolve", message: "ENTER evolve.run")
       @iteration = 0
+      @cost = 0.0
+      @history = []
       @checkpoint = create_safety_checkpoint unless dry_run
       files = find_files(path)
 
@@ -35,7 +38,7 @@ module MASTER
         break if over_budget?
 
         @iteration += 1
-        result = improve_file(file, dry_run: dry_run)
+        result = improve_file_with_retry(file, dry_run: dry_run)
         @history << result
       end
 
@@ -44,6 +47,8 @@ module MASTER
         cost: @cost,
         files_processed: @history.size,
         improvements: @history.count { |h| h[:improved] },
+        errors: @history.count { |h| h[:error] },
+        skipped: @history.count { |h| h[:skipped] },
         history: @history,
         checkpoint: @checkpoint,
       }
@@ -73,6 +78,10 @@ module MASTER
     def improve_file(file, dry_run:)
       code = File.read(file)
       return { file: file, skipped: true, reason: "too large" } if code.size > 10_000
+
+      if @llm.respond_to?(:configured?) && !@llm.configured?
+        return { file: file, skipped: true, reason: "OPENROUTER_API_KEY not configured" }
+      end
 
       # Handle shell scripts with embedded Ruby
       return improve_shell_file(file, code, dry_run: dry_run) if @language == :shell || shell_file?(file)
@@ -104,6 +113,21 @@ module MASTER
       end
     rescue StandardError => e
       { file: file, error: e.message }
+    end
+
+    def improve_file_with_retry(file, dry_run:)
+      attempts = 0
+      last = nil
+
+      begin
+        attempts += 1
+        last = improve_file(file, dry_run: dry_run)
+        return last unless last[:error] && attempts <= @max_retries
+
+        Logging.warn("evolve retry", file: file, attempt: attempts, error: last[:error])
+      end while attempts <= @max_retries
+
+      (last || { file: file, error: "unknown error" }).merge(attempts: attempts)
     end
 
     def shell_file?(file)

--- a/__predecessors/MASTER2/lib/master.rb
+++ b/__predecessors/MASTER2/lib/master.rb
@@ -86,6 +86,7 @@ require_relative "chamber"
 # Tools
 require_relative "shell"
 require_relative "analysis"
+require_relative "auto_fixer"
 require_relative "problem_solver"
 require_relative "evolve"
 require_relative "queue"

--- a/__predecessors/MASTER2/test/test_evolve_flow.rb
+++ b/__predecessors/MASTER2/test/test_evolve_flow.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "tmpdir"
+
+class TestEvolveFlow < Minitest::Test
+  class StubChamber
+    def deliberate(_code, filename:)
+      MASTER::Result.err("stub failure on #{filename}")
+    end
+  end
+
+  class StubLLM
+    def configured?
+      false
+    end
+  end
+
+  def test_run_resets_history_between_invocations
+    evolve = MASTER::Evolve.new(llm: StubLLM.new, chamber: StubChamber.new)
+
+    first = evolve.run(path: MASTER.root, dry_run: true)
+    second = evolve.run(path: MASTER.root, dry_run: true)
+
+    assert_equal first[:files_processed], second[:files_processed]
+    assert_equal first[:skipped], second[:skipped]
+    assert_equal first[:errors], second[:errors]
+    refute_empty second[:history]
+  end
+
+  def test_run_reports_skipped_when_llm_not_configured
+    Dir.mktmpdir do |dir|
+      lib_dir = File.join(dir, "lib")
+      FileUtils.mkdir_p(lib_dir)
+      file = File.join(lib_dir, "sample.rb")
+      File.write(file, "puts 'hi'\n")
+
+      evolve = MASTER::Evolve.new(llm: StubLLM.new, chamber: StubChamber.new)
+      result = evolve.run(path: dir, dry_run: true)
+
+      assert_equal 1, result[:files_processed]
+      assert_equal 1, result[:skipped]
+      assert_equal 0, result[:errors]
+      assert_equal "OPENROUTER_API_KEY not configured", result[:history].first[:reason]
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
- Make the repository `selfrun` flow do a full, phase-driven scan-and-remediate pass (not an ad-hoc partial path) so the tool can analyze, report, and optionally autofix a broad set of repository artifacts with clearer observability.
- Improve observability and auditability by emitting dmesg-style events for phases and per-file operations so external agents/humans can inspect what happened during runs.
- Harden automated remediation with layered autofix (local `AutoFixer` then LLM fallback) and guard LLM-dependent flows when no API key is configured.
- Stabilize `Evolve` run behavior by resetting run-state between invocations and adding bounded retry behavior for transient per-file failures.

### Description
- Rewired CLI so `bin/master selfrun` calls the integrated `Commands.selftest_full` orchestrator and honors its return/exit semantics via `send(:selftest_full)` and proper exit code handling.
- Replaced the old `selftest_full` single-purpose routine with a multi-phase orchestrator in `lib/commands/misc_commands.rb` that: collects a broad set of target files (`.rb`, shell scripts, YAML/JSON/MD, gemspec, Gemfile), accounts lines per file, runs Ruby syntax checks, aggregates lexical and conceptual violations, attempts autofix in apply mode (prefers `AutoFixer`, then LLM), runs `CodeReview.opportunities`, attempts a `Council` critique if LLM is available, and summarizes git status; the routine emits dmesg-style logs (`selfrun`, `file0`, `viol0`, `fix0`, `opps0`) for visibility.
- Added a lightweight `AutoFixer` shim at `lib/auto_fixer.rb` that offers a predictable API when no external auto-fix engine is installed and supports rollback/history for safe dry-runs.
- Improved CLI `evolve` output in `lib/commands/code_commands.rb` to normalize blank paths, show the analyzed `Path`, and include `Skipped`/`Errors` counts and contextual notes when there is no work to do.
- Made `Evolve` more robust in `lib/evolve.rb` by resetting `@cost` and `@history` at run start, adding a `max_retries` constructor option, and wrapping per-file improvements in `improve_file_with_retry` to retry transient errors and surface `attempts` in the result.
- Hardened `LLM` integration in `lib/llm.rb` to tolerate missing `ruby_llm` at runtime (warn and disable API calls), return friendly `Result.err` messages when the gem or API key is missing, and added small model selection and configuration improvements in `lib/llm/models.rb` and `lib/llm/budget.rb` to work without live provider metadata.
- Require the new `auto_fixer` from `lib/master.rb` so the shim is available to commands and tests.
- Added focused unit tests in `test/test_evolve_flow.rb` to verify run-state reset behavior and explicit skip accounting when the LLM is not configured.

### Testing
- Ran `ruby -c lib/commands/misc_commands.rb` and `ruby -c bin/master` to validate syntax and they succeeded; both returned `Syntax OK`.
- Ran the integration suite with `ruby -Ilib:test test/test_integration.rb` and the test run completed successfully with zero failures.
- Executed a dry-run of the new self-run with `./bin/master selfrun` and observed a full file+line scan, per-file violation reporting, opportunity phase attempt, council phase fallback when LLM unavailable, and a git status summary (completed successfully in this environment).
- Ran the new unit tests `test/test_evolve_flow.rb` as part of the test suite and observed success (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69933aa57488832abfb1f752dbb4c325)