### PR TITLE
Add concrete repo layout policy and sprawl audit script

### DIFF
--- a/FILE_SPRAWL_REDUCTION.md
+++ b/FILE_SPRAWL_REDUCTION.md
@@ -1,0 +1,95 @@
+# File Sprawl Reduction Plan
+
+## Current Snapshot
+
+- Total tracked files (via `rg --files`): **4,825**.
+- Most files live under three top-level directories:
+  - `study/` (~2,150 files)
+  - `MASTER/` (~2,137 files)
+  - `__predecessors/` (~419 files)
+- Path depth is high for many files (hundreds at 8+ folder levels), which increases navigation and duplication risk.
+
+## Goals
+
+1. Make ownership clear by top-level directory.
+2. Reduce duplicate content across `MASTER/`, `study/`, and `__predecessors/`.
+3. Keep active code shallow and archives explicit.
+
+## Recommended Target Structure
+
+- `apps/` — runnable projects and deployable code only.
+- `knowledge/` — curated reference material you actually use.
+- `archive/` — frozen legacy snapshots and predecessor trees.
+- `scripts/` — operational scripts at stable, documented paths.
+- `docs/` — project docs, plans, and architecture notes.
+
+## Practical Reduction Moves
+
+### 1) Archive low-churn trees
+
+Move historical and snapshot-heavy folders into a single `archive/` namespace:
+
+- `__predecessors/` -> `archive/predecessors/`
+- Any one-off snapshots from `MASTER/` -> `archive/master-snapshots/`
+
+Why: keeps working surface small without deleting history.
+
+### 2) De-duplicate mirrored “awesome” content
+
+There are mirrored trees under both `study/awesome-llm-apps` and `MASTER/knowledge/awesome/awesome-llm-apps`.
+
+Pick one canonical location (recommended: `knowledge/awesome/awesome-llm-apps`) and:
+
+- keep only canonical files there,
+- replace duplicates with links/references,
+- add a short migration map for old paths.
+
+### 3) Split active vs reference inside `MASTER/`
+
+`MASTER/` currently mixes executable code, deploy configs, docs, data, and knowledge.
+
+Refactor by intent:
+
+- `MASTER/lib`, `MASTER/exe`, `MASTER/web` -> `apps/master/`
+- `MASTER/DEPLOY` -> `apps/master/deploy/`
+- `MASTER/docs` -> `docs/master/`
+- `MASTER/knowledge` -> `knowledge/master/`
+
+### 4) Set a max path depth policy for new files
+
+Adopt a lightweight rule in contributor docs:
+
+- default max depth: 5 levels below repo root,
+- deeper paths require a reason in PR description.
+
+This prevents future nested sprawl.
+
+### 5) Add “placement rules” in one page
+
+Create a short `docs/repo-layout.md` defining:
+
+- what belongs in each top-level directory,
+- where generated files go,
+- where experiments go,
+- what must be archived vs deleted.
+
+## 2-Week Low-Risk Rollout
+
+### Week 1
+
+1. Create target top-level folders (`apps`, `knowledge`, `archive`, `docs`, `scripts`).
+2. Move `__predecessors` to `archive/predecessors`.
+3. Add path migration notes and shell aliases/symlinks if needed.
+
+### Week 2
+
+1. Choose canonical “awesome” tree and remove duplicates.
+2. Move `MASTER/docs` and `MASTER/knowledge` into new homes.
+3. Enforce placement/depth checks in CI (warning-only first).
+
+## Success Metrics
+
+- 25-40% fewer files in the active working set (`apps + scripts + docs`).
+- >80% reduction in duplicate files across `study/` and `MASTER/knowledge/`.
+- Median path depth reduced by at least 1 level.
+

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -1,0 +1,40 @@
+# Repository Layout Rules
+
+This page defines **where new files should go** and how to avoid further file sprawl.
+
+## Top-level ownership
+
+- `apps/` — runnable applications and deployable services.
+- `knowledge/` — curated references intentionally kept for active use.
+- `docs/` — design docs, plans, and repository-level guidance.
+- `scripts/` — operational helper scripts used by humans/CI.
+- `archive/` — frozen legacy trees and historical snapshots.
+
+## Placement rules
+
+1. Prefer adding new work under one of the five folders above.
+2. Do not create a new top-level folder without a short rationale in PR notes.
+3. Experimental work should live in `apps/experiments/<topic>/` and be deleted or promoted within 30 days.
+4. Generated outputs should be written to `tmp/` (or tool-specific cache dirs), not committed unless explicitly required.
+
+## Depth policy
+
+- Default maximum depth is **5 levels below repository root**.
+- If a path must exceed 5 levels, include one sentence in PR notes explaining why.
+
+## Duplication policy
+
+- Keep one canonical copy of a file tree.
+- If compatibility requires old paths, prefer symlinks or short forwarding notes over duplicated content.
+
+## Migration mapping (initial)
+
+- `__predecessors/` -> `archive/predecessors/`
+- `MASTER/knowledge/awesome/awesome-llm-apps` + `study/awesome-llm-apps` -> `knowledge/awesome/awesome-llm-apps` (canonical target)
+
+## Quick checklist for PR authors
+
+- [ ] New files are in an allowed top-level area.
+- [ ] Any deep path (>5) is justified in PR notes.
+- [ ] No duplicate tree was introduced.
+- [ ] Generated files are excluded or intentionally documented.

--- a/scripts/repo_sprawl_check.sh
+++ b/scripts/repo_sprawl_check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple warning-only sprawl checks.
+# Exit code is always 0 unless command/runtime failures occur.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+max_depth="${1:-5}"
+
+echo "[repo-sprawl] scanning tracked files with max depth=${max_depth}"
+
+# depth is number of '/' separators in path
+# e.g., a/b/c.txt => depth 2
+violations="$(rg --files | awk -F/ -v max="$max_depth" 'NF-1 > max {print}')"
+
+if [[ -n "$violations" ]]; then
+  echo "[repo-sprawl] WARNING: files deeper than ${max_depth} levels:"
+  echo "$violations" | sed -n '1,50p'
+  total="$(echo "$violations" | wc -l | tr -d ' ')"
+  if [[ "$total" -gt 50 ]]; then
+    echo "[repo-sprawl] ... and $((total - 50)) more"
+  fi
+else
+  echo "[repo-sprawl] OK: no files deeper than ${max_depth} levels"
+fi
+
+# Report top-level spread for quick visibility
+
+echo "[repo-sprawl] top-level directory counts (tracked files):"
+rg --files | awk -F/ '{print $1}' | sort | uniq -c | sort -nr | sed -n '1,20p'


### PR DESCRIPTION
### Motivation
- Convert the high-level file-sprawl proposal into immediately actionable repository rules and lightweight tooling. 
- Reduce ambiguity about where new content belongs and prevent future deep/nested path sprawl via a simple depth policy. 
- Provide an easy-to-run check that can be adopted in CI as a warning-only safeguard before enforcing changes. 

### Description
- Add `FILE_SPRAWL_REDUCTION.md` capturing the repository snapshot, target top-level layout, migration moves, rollout plan, and success metrics. 
- Add `docs/repo-layout.md` defining top-level ownership (`apps`, `knowledge`, `docs`, `scripts`, `archive`), placement/duplication rules, a default max-depth policy, and an initial migration map. 
- Add executable `scripts/repo_sprawl_check.sh`, a warning-only audit that reports files deeper than a configurable threshold (default `5`) and prints top-level tracked-file distribution. 
- Create `docs/` and `scripts/` and commit the new files with executable bit set for the script. 

### Testing
- Ran `./scripts/repo_sprawl_check.sh 5` successfully and observed the expected warning output listing over-depth files and top-level counts. 
- Verified working tree state with `git status --short` and committed the new files using `git add`/`git commit` without errors. 
- Inspected created files with `sed -n`/`nl -ba` to confirm the contents of `FILE_SPRAWL_REDUCTION.md`, `docs/repo-layout.md`, and `scripts/repo_sprawl_check.sh` were written as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c60ab59c832aabfac07655b5bccf)