### PR TITLE
Add MASTER boot troubleshooting for Rubygems proxy 403

### DIFF
--- a/MASTER/README.md
+++ b/MASTER/README.md
@@ -27,3 +27,16 @@ A live canvas — the openclaw inheritance — sits at `/canvas`. The agent draw
 Deploy through `DEPLOY/openbsd/openbsd.sh`, two stages, resumable.
 
 MIT.
+
+
+## Debug note: Bundler and proxy 403s
+
+If `bundle install` fails with `Gem::Net::HTTPClientException: 403 "Forbidden"` in containerized environments, verify proxy wiring before debugging MASTER itself. In this environment, Rubygems requests are routed through `http://proxy:8080`; if that proxy blocks `rubygems.org`, `bundle exec ruby exe/master orient` fails before app boot because dependencies (for example `zeitwerk`) never install.
+
+Fast checks:
+
+- `gem sources --list` should include `https://rubygems.org/`.
+- `env | rg -i 'proxy|rubygems|bundle'` should reveal active proxy variables.
+- `gem install zeitwerk -v 2.7.5` isolates network/proxy failure from MASTER code.
+
+Treat this as infrastructure breakage, not an application bug, unless gems install cleanly and MASTER still fails to boot.


### PR DESCRIPTION
### Motivation
- Document a common MASTER bootstrap failure where Bundler/Gem requests are blocked by an environment proxy returning `403 Forbidden`, which prevents required gems (for example `zeitwerk`) from installing and stops MASTER from booting.

### Description
- Add a "Debug note: Bundler and proxy 403s" section to `MASTER/README.md` with concise diagnostics and commands to separate infrastructure/proxy issues from application bugs, including `gem sources --list`, `env | rg -i 'proxy|rubygems|bundle'`, and `gem install zeitwerk -v 2.7.5`.

### Testing
- Ran `bundle exec ruby exe/master orient` (failed due to missing gems), `bundle install` and `bundle install --full-index` (both failed with `Gem::Net::HTTPClientException: 403 "Forbidden"`), `gem install zeitwerk -v 2.7.5` (failed with same 403), and `gem sources --list && env | rg -i 'gem|bundle|rubygems|http_proxy|https_proxy'` (succeeded and showed `https://rubygems.org/` and active proxy environment variables).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf4fca698832a969339f5d026e20c)