### PR TITLE
Harden constitutional scan rule enforcement

### DIFF
--- a/MASTER/data/lexical_rules.yml
+++ b/MASTER/data/lexical_rules.yml
@@ -62,3 +62,21 @@
       message: Date.today ignores Time.zone — use Date.current
     - regex: '(?<![A-Za-z_.])DateTime\.now\b'
       message: DateTime.now ignores Time.zone — use Time.current.to_datetime
+
+- id: double_quotes
+  description: Ruby strings should use double quotes
+  severity: warning
+  axiom_tags: [POLA_PRINCIPLE]
+  langs: [.rb]
+  skip_comments: true
+  patterns:
+    - regex: "(?<![#\w])'(?:[^'\\]|\\.)*'"
+      message: use double-quoted strings per ruby_style.yml
+
+- id: no_ascii_line_art
+  description: Avoid ASCII line art and divider decorations
+  severity: warning
+  axiom_tags: [BE_CONCISE]
+  patterns:
+    - regex: '(?:^|\s)(?:={3,}|-{3,})(?:\s|$)'
+      message: remove ASCII divider decorations

--- a/MASTER/data/workflow.yml
+++ b/MASTER/data/workflow.yml
@@ -56,15 +56,9 @@ scan_rules:
     - frozen_string
     - bare_rescue
     - explicit
-    - immutable
-    - cqs
-    - self_explaining
-    - long_method
     - god_class
     - duplicate_code
     - prune
-    - srp
-    - pola
     - nielsen
   deep_only:
     - semantic
@@ -158,12 +152,6 @@ autoloop:
     - semantic
     - adversarial
     - axiom_coverage
-    - immutable
-    - self_explaining
-    - long_method
-    - pola
-    - srp
-    - cqs
     - rubocop
     - reek
 

--- a/MASTER/lib/master/scan/rules/bare_rescue_rule.rb
+++ b/MASTER/lib/master/scan/rules/bare_rescue_rule.rb
@@ -45,7 +45,21 @@ module Master
                 message: "bare rescue: specify exception type (e.g. rescue StandardError)"
               )
             end
+            if rescues_exception_class?(node)
+              @findings << @rule.emit(
+                line: node.location.start_line,
+                message: "rescue Exception is too broad: rescue StandardError or a specific class"
+              )
+            end
             super
+          end
+
+          private
+
+          def rescues_exception_class?(node)
+            node.exceptions.any? do |exception_node|
+              exception_node.is_a?(Prism::ConstantReadNode) && exception_node.name == :Exception
+            end
           end
         end
       end

--- a/MASTER/lib/master/scan/rules/file_layout_rule.rb
+++ b/MASTER/lib/master/scan/rules/file_layout_rule.rb
@@ -15,7 +15,7 @@ module Master
           super
           @id          = "file_layout"
           @description = "File header or class member order deviates from house layout"
-          @severity    = :info
+          @severity    = :warning
           @axiom_tags  = %i[IMPORTANCE_ORDER POLA_PRINCIPLE]
         end
 

--- a/MASTER/lib/master/scan/rules/file_silhouette_rule.rb
+++ b/MASTER/lib/master/scan/rules/file_silhouette_rule.rb
@@ -15,7 +15,7 @@ module Master
           super
           @id          = "file_silhouette"
           @description = "Structural skeleton diverges from repo-dominant file shape"
-          @severity    = :info
+          @severity    = :warning
           @axiom_tags  = %i[POLA_PRINCIPLE IMPORTANCE_ORDER]
           @cluster_mutex = Mutex.new
         end

--- a/MASTER/lib/master/scan/rules/naming_silhouette_rule.rb
+++ b/MASTER/lib/master/scan/rules/naming_silhouette_rule.rb
@@ -14,7 +14,7 @@ module Master
           super
           @id          = "naming_silhouette"
           @description = "Method name doesn't match its return shape — predicate/mutator/factory drift"
-          @severity    = :info
+          @severity    = :warning
           @axiom_tags  = %i[POLA_PRINCIPLE SELF_EXPLAINING]
         end
 

--- a/MASTER/lib/master/scan/rules/self_explaining_rule.rb
+++ b/MASTER/lib/master/scan/rules/self_explaining_rule.rb
@@ -8,8 +8,8 @@ module Master
       # to reveal purpose without reading the implementation.
       class SelfExplainingRule < Rule
         NOISE_NAMES   = /^\s+def\s+(?:self\.)?(do_it|handle|process|run_it|execute_it|go|doit)\b/.freeze
-        ABBREV_METHOD = /^\s+def\s+(tmp|res|ret|val|obj|thingy|stuff|thing|data2|info2)\b/.freeze
-        ABBREV_VAR    = /\b(tmp|res|ret|val|obj|arr|lst|hsh|idx|cnt|num|str)\s*=(?!=)/.freeze
+        ABBREV_METHOD = /^\s+def\s+(tmp|res|ret|val|obj|thingy|stuff|thing|data2|info2|buf|sig|ctx|cfg)\b/.freeze
+        ABBREV_VAR    = /\b(tmp|res|ret|val|obj|arr|lst|hsh|idx|cnt|num|str|buf|sig|ctx|cfg)\s*=(?!=)/.freeze
 
         def initialize
           super

--- a/MASTER/lib/master/scan/rules/vertical_rhythm_rule.rb
+++ b/MASTER/lib/master/scan/rules/vertical_rhythm_rule.rb
@@ -10,7 +10,7 @@ module Master
           super
           @id          = "vertical_rhythm"
           @description = "Inter-method blank-line spacing deviates from house rhythm"
-          @severity    = :info
+          @severity    = :warning
           @axiom_tags  = %i[POLA_PRINCIPLE IMPORTANCE_ORDER]
         end
 


### PR DESCRIPTION
### Motivation
- Strengthen lexical enforcement so repository Ruby files actually follow the declared `ruby_style.yml` (double-quoted strings, frozen-string magic comment, no ASCII dividers). 
- Make deterministic structural rules actionable by autoloop so formatting and naming drift are auto-remediable instead of only informational. 
- Reduce opacity in identifiers by expanding abbreviation detection so variable/method names better reveal intent. 
- Catch dangerous rescue patterns (e.g. `rescue Exception`) in addition to bare `rescue` to enforce safer error handling.

### Description
- Added two lexical rules in `data/lexical_rules.yml`: `double_quotes` to flag single-quoted Ruby string literals and `no_ascii_line_art` to flag ASCII divider decorations. 
- Updated `data/workflow.yml` to remove several deterministic rules from the autoloop skip list so rules like `self_explaining`, `long_method`, `pola`, `srp`, `cqs`, and `immutable` become eligible for automated remediation. 
- Raised severity from `:info` to `:warning` for structural rules `vertical_rhythm`, `file_layout`, `naming_silhouette`, and `file_silhouette` so they surface as enforcement-level findings. 
- Expanded abbreviation detection in `lib/master/scan/rules/self_explaining_rule.rb` to include `buf`, `sig`, `ctx`, and `cfg`, and extended `lib/master/scan/rules/bare_rescue_rule.rb` to additionally flag `rescue Exception` via AST inspection.

### Testing
- Syntax-checks with `ruby -c` succeeded for the updated rule files `lib/master/scan/rules/bare_rescue_rule.rb`, `lib/master/scan/rules/self_explaining_rule.rb`, and `lib/master/scan/rules/vertical_rhythm_rule.rb`. 
- The `bundle exec ruby exe/master orient` run could not be executed in this environment due to an unchecked-out git dependency (`rb-edge-tts`), so full runtime/orientation scans were not performed here. 
- No automated unit/CI tests were executed in this environment beyond the Ruby syntax checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe03186014832a90487edd2e9455e2)