### PR TITLE
Improve MASTER operator ergonomics and LLM onboarding

### DIFF
--- a/MASTER/QUICKSTART.md
+++ b/MASTER/QUICKSTART.md
@@ -1,0 +1,45 @@
+# MASTER Quickstart (External LLMs)
+
+MASTER is a constitutional coding agent in Ruby. Read this first, then run `/orient` for full doctrine.
+
+1) Golden rule
+- Preserve, then improve, never break.
+- Read full files before editing.
+- Keep patches minimal and reversible.
+
+2) Non-negotiables
+- No fabricated claims; show evidence from files/commands.
+- No bare `rescue`; rescue specific exceptions.
+- Prefer named constants over magic literals.
+- Use string methods before regex when possible.
+- Dependency-inject collaborators; avoid hidden instantiation.
+
+3) Style baseline
+- `# frozen_string_literal: true` in Ruby files.
+- Double-quoted strings.
+- Guard clauses first.
+- Endless method style for single expressions.
+- Clear names; avoid abbreviations like `idx`, `tmp`, `sig`.
+
+4) How MASTER works
+- Pipeline: Intake → Infer → Route → Guard → Execute → Council/Lint → Prune → Memo → Render.
+- Scans enforce structure/style rules from `data/rules.yml` and `data/ruby_style.yml`.
+- Sweep can auto-fix but must remain safe and auditable.
+
+5) Core commands
+- `/scan [profile] [path]` check a file/dir.
+- `/sweep [path]` autofix pass.
+- `/autoloop [N]` repeated scan/fix loops.
+- `/diag` runtime snapshot.
+- `/why <rule>` explain one rule.
+- `/help` command catalog.
+
+6) Web auth model
+- Token-authenticated operator gets full tools.
+- Visitor mode is restricted to safe tools.
+
+7) If uncertain
+- Ask for the specific rule section instead of guessing.
+- Prefer explicit tradeoffs and smallest safe change.
+
+Full reference: `CONVENTIONS.md` and `/orient`.

--- a/MASTER/lib/master/cli.rb
+++ b/MASTER/lib/master/cli.rb
@@ -31,6 +31,7 @@ module Master
       @bg_thread       = nil
       @seen_violations = {}
       @user_active     = false
+      @last_scan_at    = nil
     end
 
     def run(initial_message = nil)
@@ -104,9 +105,8 @@ module Master
 
     def repl_loop
       while @running
+        print_dashboard
         tokens = @session.token_est
-        status = @renderer.status_row(uptime: @renderer.uptime, turns: @session.messages.size, violations: @violations)
-        puts status if status
         print @renderer.prompt_line(
           @agent.model, @session.phase,
           last_ok: @last_ok, violations: @violations, tokens: tokens, cost: @session.cost
@@ -176,12 +176,34 @@ module Master
       return unless result.is_a?(Master::Result::Ok)
 
       @violations = count_violations(result.value!)
+      @last_scan_at = Time.now
       return if @violations.zero?
 
       puts "\n#{@renderer.render("boot scan: #{@violations} violation(s)", mode: :dim)}"
       print @renderer.prompt_line(@agent.model, @session.phase, last_ok: @last_ok, violations: @violations)
     rescue StandardError => e
       @bus&.publish("cli:warn", error: e.message)
+    end
+
+    def print_dashboard
+      used = @session.cost.to_f
+      max_budget = @config["budget_max"] || 10.0
+      mood = @last_ok ? "focused" : "recovering"
+      last_scan = @last_scan_at ? "#{((Time.now - @last_scan_at).round)}s ago" : "never"
+      files = Master::CommandRegistry.tree_lines(@root).size
+      puts @renderer.command_summary(
+        model: @agent.model,
+        budget_used: used,
+        budget_max: max_budget,
+        violations: @violations,
+        phase: @session.phase,
+        mood: mood,
+        uptime: @renderer.uptime,
+        last_scan: last_scan,
+        file_count: files
+      )
+    rescue StandardError
+      nil
     end
 
     def changed_lib_files(lib_dir)

--- a/MASTER/lib/master/command_registry.rb
+++ b/MASTER/lib/master/command_registry.rb
@@ -24,9 +24,13 @@ module Master
   buf.string
 },
 "help" => ->(_ctx) {
-
-          "just talk. intent is inferred automatically.\n" \
-          "exit with /exit or ctrl-C twice."
+          [
+            "session: /save /clear /history [N] /tokens /undo /redo /exit",
+            "scan: /scan [profile] [path] /sweep [path] /autoloop [N]",
+            "model: /model [id|list] /mode /persona /task",
+            "memory: /mem /topic /rsi",
+            "system: /diag [/section] /tree [N] /orient /help"
+          ].join("\n")
         }
       )
     end
@@ -39,8 +43,16 @@ module Master
       {
         "clear"  => ->(_ctx) { session.clear!; "context cleared" },
         "save"   => ->(_ctx) { session.save!; "session saved" },
+        "history" => ->(ctx) {
+          n = ctx[:args].to_s.strip.to_i
+          n = 10 if n <= 0
+          recent = session.messages.last(n)
+          next "history: empty" if recent.empty?
+          recent.map { |m| "[#{m[:role]}] #{m[:content].to_s.gsub(/\s+/, ' ')[0, 120]}" }.join("\n")
+        },
         "tokens" => ->(_ctx) { "~#{session.token_est} tokens" },
         "undo"   => ->(_ctx) { result = undo.undo!; result.ok? ? "reverted: #{result.value!}" : result.message },
+        "redo"   => ->(_ctx) { result = undo.redo!; result.ok? ? "reapplied: #{result.value!}" : result.message },
         "dmesg"  => ->(_ctx) { logging.dmesg },
         "cost"   => ->(_ctx) { "$#{"%.4f" % session.cost}" },
         "config" => ->(_ctx) { config.data.inspect }

--- a/MASTER/lib/master/renderer.rb
+++ b/MASTER/lib/master/renderer.rb
@@ -94,6 +94,15 @@ module Master
       @p.dim(bits.join(" "))
     end
 
+    def command_summary(model:, budget_used:, budget_max:, violations:, phase:, mood:, uptime:, last_scan:, file_count:)
+      budget = format("$%.2f / $%.2f", budget_used.to_f, budget_max.to_f)
+      [
+        "model: #{short_model(model)} (#{provider_for(model)})    budget: #{budget}    violations: #{violations}",
+        "phase: #{phase}    mood: #{mood}    uptime: #{uptime}    last scan: #{last_scan}",
+        "tree: #{file_count} files  --  /tree [N]   /diag   /orders   /help"
+      ].map { |line| @p.dim(line) }.join("\n")
+    end
+
     def token_bar(tokens)
       return "" unless tokens && tokens > 0
       budget = (@config["token_budget"] || TOKEN_BUDGET).to_i

--- a/MASTER/lib/master/undo.rb
+++ b/MASTER/lib/master/undo.rb
@@ -15,6 +15,7 @@ module Master
       @root    = root
       @journal = File.join(root, ".master", "undo_journal.jsonl")
       @stack   = load_journal
+      @redo    = []
     end
 
     def snapshot(path)
@@ -36,9 +37,27 @@ module Master
 
       steps.times do
         entry = @stack.pop
+        @redo << { "path" => entry["path"], "content" => (File.exist?(entry["path"]) ? File.read(entry["path"]) : nil), "ts" => Time.now.to_i }
         restore(entry["path"], entry["content"])
         paths << entry["path"]
         @bus&.publish("undo:applied", path: paths.last)
+      end
+
+      persist_journal
+      Result.ok(paths.size == 1 ? paths.first : paths)
+    end
+
+    def redo!(steps: 1)
+      return Result.err("nothing to redo", category: :validation) if @redo.empty?
+
+      steps = [steps, @redo.size].min
+      paths = []
+      steps.times do
+        entry = @redo.pop
+        @stack << { "path" => entry["path"], "content" => (File.exist?(entry["path"]) ? File.read(entry["path"]) : nil), "ts" => Time.now.to_i }
+        restore(entry["path"], entry["content"])
+        paths << entry["path"]
+        @bus&.publish("redo:applied", path: paths.last)
       end
 
       persist_journal


### PR DESCRIPTION
### Motivation
- Provide immediate situational awareness after each command with a unified dashboard so the operator need not run multiple probes to know system state.
- Make common session workflows faster and safer by exposing history, redo, and clearer discoverability for commands.
- Improve onboarding for external LLMs with a concise quick-start conventions card to reduce prompt bloat and speed rule lookups.

### Description
- Added a multi-line post-command dashboard via `Renderer#command_summary` and `CLI#print_dashboard`, and track scan recency with `@last_scan_at` (set in `boot_scan`).
- Added session ergonomics: `history` and expanded `help` output in the command registry, plus a `redo` command wired to the undo system in `CommandRegistry`.
- Extended the undo subsystem with a redo journal (`@redo`) and `Undo#redo!` to allow reapplying undone snapshots and emit `redo:applied` events.
- Added `MASTER/QUICKSTART.md` as a concise external-LLM conventions card and updated the CLI help text to list grouped command categories.

### Testing
- Syntax-checked the modified Ruby files with `ruby -c MASTER/lib/master/cli.rb`, `ruby -c MASTER/lib/master/renderer.rb`, `ruby -c MASTER/lib/master/command_registry.rb`, and `ruby -c MASTER/lib/master/undo.rb`, all of which returned `Syntax OK`.
- Attempted to run the full orient stream with `bundle exec ruby exe/master orient`, but this environment failed due to a missing git-sourced gem checkout (`rb-edge-tts`), so full runtime validation could not be completed here.
- Verified the code changes load and basic CLI plumbing (syntax and local static checks) succeeded; no automated unit test suite was run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe046ff320832aaaae93d5c97ada4d)