### PR TITLE
Flatten scan behavior to always run full deep checks

### DIFF
--- a/MASTER/data/standing_orders.yml
+++ b/MASTER/data/standing_orders.yml
@@ -1,11 +1,11 @@
 ---
 - name: triad_default
-  description: Default pipeline — deep scan, autofix sweep, council review. Runs hourly
+  description: Default pipeline — full scan, autofix sweep, council review. Runs hourly
     and after any /chat or CLI session that mutated MASTER source. User never types
     this; agent_commands/triad_command runs all three.
   trigger: scheduled
   interval_s: 3600
-  command: triad deep .
+  command: triad .
   enabled: true
   state: done
   last_run_at: 1778205973

--- a/MASTER/data/workflow.yml
+++ b/MASTER/data/workflow.yml
@@ -51,65 +51,6 @@ code_principles:
     rule: RESULT_MONAD
     statement: "Use respond_to?(:ok?) not is_a?(Result) for duck‑typing."
 
-scan_rules:
-  standard_depth:
-    - frozen_string
-    - bare_rescue
-    - explicit
-    - immutable
-    - cqs
-    - self_explaining
-    - long_method
-    - god_class
-    - duplicate_code
-    - prune
-    - srp
-    - pola
-    - nielsen
-  deep_only:
-    - semantic
-    - adversarial
-  hunt_only:
-    - rubocop
-    - reek
-  notes:
-    nielsen: "puts is NOT debug output in a CLI. Only p, pp, binding.pry, debugger are."
-    prune: "Loads patterns from data/rules.yml (voice.strunk) — single source of truth."
-    semantic: "Loads philosophy from data/rules.yml (zen + voice) — single source of truth."
-    deep_caution: "deep adds 2 LLM calls per file. With 90 files at 8 req/min free tier = 22+ minutes."
-
-principle_groups:
-  axioms:      [frozen_string, explicit, immutable, self_explaining]
-  solid:       [srp, cqs, pola]
-  clean_code:  [long_method, god_class, duplicate_code, bare_rescue]
-  interface:   [nielsen, prune]
-  llm_rules:   [semantic, adversarial]
-  heavy:       [rubocop, reek]
-  quick:       [frozen_string, bare_rescue, explicit, long_method, god_class]
-  critical:    [frozen_string, bare_rescue, explicit, immutable, srp, cqs]
-
-scan_profiles:
-  quick:
-    depth: standard
-    rules: quick
-    description: "Fast scan — core violations only"
-  full:
-    depth: deep
-    rules: "*"
-    description: "All rules, deep LLM analysis"
-  critical:
-    depth: standard
-    rules: critical
-    description: "Critical issues blocking ship"
-  solid:
-    depth: standard
-    rules: solid
-    description: "SOLID principles focus"
-  axioms:
-    depth: standard
-    rules: axioms
-    description: "Constitutional axioms only"
-
 conflicts:
   strategy: highest_priority_wins
   rules:

--- a/MASTER/lib/master/command_registry/agent_commands.rb
+++ b/MASTER/lib/master/command_registry/agent_commands.rb
@@ -29,11 +29,11 @@ module Master
       {
         "triad" => ->(ctx) {
           target = arg_for(ctx)
-          target = "deep ." if target.empty?
+          target = "." if target.empty?
           parts = []
           bus&.publish("triad:start", target: target)
           parts << "scan:\n#{cmds['scan'].call(args: target)}"
-          parts << "sweep:\n#{cmds['sweep'].call(args: target.sub(/\Adeep\s*/, ''))}"
+          parts << "sweep:\n#{cmds['sweep'].call(args: target)}"
           parts << "tribunal:\n#{run_tribunal(deliberation, parts.join("\n\n"), target)}"
           bus&.publish("triad:done")
           parts.join("\n\n")
@@ -91,60 +91,36 @@ module Master
     end
 
     def dispatch_scan(scanner, root, arg)
-      profile, depth, rule_filter = resolve_scan_profile(arg, root)
-      pairs = collect_scan_pairs(scanner, root, arg, depth)
+      pairs = collect_scan_pairs(scanner, root, arg)
       return pairs if pairs.is_a?(String)
-      format_scan_results(pairs, profile, rule_filter)
+      format_scan_results(pairs)
     end
 
-    def collect_scan_pairs(scanner, root, arg, depth)
-      raw_arg    = arg.sub(/\A(?:deep|quick|full|critical|solid|axioms)\s*/, "").strip
-      target_arg = raw_arg.empty? ? nil : File.expand_path(raw_arg)
+    def collect_scan_pairs(scanner, root, arg)
+      target_arg = arg.empty? ? nil : File.expand_path(arg)
       if target_arg && File.file?(target_arg)
-        [[target_arg, scanner.scan(target_arg, depth:)]]
+        [[target_arg, scanner.scan(target_arg, depth: :deep)]]
       else
         dir = (target_arg && File.directory?(target_arg)) ? target_arg : File.join(root, "lib")
-        result = scanner.scan_dir(dir, depth:, glob: "**/*", stream: true)
+        result = scanner.scan_dir(dir, depth: :deep, glob: "**/*", stream: true)
         result.ok? ? result.value! : "scan failed"
       end
     end
 
-    def format_scan_results(pairs, profile, rule_filter)
+    def format_scan_results(pairs)
       by_rule = Hash.new { |h, k| h[k] = [] }
       pairs.each do |_file, file_result|
-        Result.wrap(file_result).value_or([]).each do |v|
-          next if rule_filter && !rule_filter.include?(v[:rule].to_s)
-          by_rule[v[:rule].to_s] << v
-        end
+        Result.wrap(file_result).value_or([]).each { |v| by_rule[v[:rule].to_s] << v }
       end
       total  = by_rule.values.sum(&:size)
-      header = profile ? "[profile: #{profile}] " : ""
-      return "#{header}clean -- no violations" if total.zero?
+      return "clean -- no violations" if total.zero?
       lines = by_rule.sort_by { |_, vs| -vs.size }.flat_map do |rule, vs|
         ["[#{rule}] #{vs.size}"] + vs.first(3).map { |v| "  L#{v[:line]}: #{v[:message][0, VIOLATION_TRUNCATE]}" }
       end
-      lines << "#{header}#{total} total violations"
+      lines << "#{total} total violations"
       lines.join("\n")
     end
 
-    def resolve_scan_profile(arg, root)
-      groups, profiles = load_workflow_profiles(root)
-      profile_name = %w[quick full critical solid axioms].find { |p| arg.start_with?(p) }
-      return [nil, :deep, nil] if profile_name.nil?
-
-      cfg         = profiles[profile_name] || {}
-      depth       = (cfg["depth"] == "deep") ? :deep : :standard
-      rule_ids    = groups[cfg["rules"].to_s]
-      rule_filter = (rule_ids && cfg["rules"] != "*") ? rule_ids.map(&:to_s).to_set : nil
-      [profile_name, depth, rule_filter]
-    end
-
-    def load_workflow_profiles(root)
-      data = Master.load_yaml(File.join(root, "data", "workflow.yml"))
-      [data["principle_groups"] || {}, data["scan_profiles"] || {}]
-    rescue StandardError
-      [{}, {}]
-    end
 
     def model_agent_commands(ai:, root:, infra:)
       council_meta_commands(ai:, root:).merge(model_commands(ai:, root:, infra:))

--- a/MASTER/lib/master/scan/scanner.rb
+++ b/MASTER/lib/master/scan/scanner.rb
@@ -18,7 +18,7 @@ module Master
         @mutex = Mutex.new
       end
 
-      def scan(path, depth: :standard)
+      def scan(path, depth: :deep)
         return Result.err("file not found: #{path}", category: :validation) unless File.exist?(path)
 
         code     = File.read(path, encoding: "UTF-8")
@@ -31,7 +31,7 @@ module Master
         Result.err("scan failed: #{e.message}", category: :unknown)
       end
 
-      def scan_dir(dir, depth: :standard, glob: SCAN_GLOB, stream: false)
+      def scan_dir(dir, depth: :deep, glob: SCAN_GLOB, stream: false)
         paths   = Dir.glob(File.join(dir, glob)).sort
         results = Array.new(paths.size)
         parallel_each(paths) { |path, idx| results[idx] = scan_one(dir, path, depth, stream) }
@@ -41,7 +41,7 @@ module Master
       end
 
       # Scan only files changed since git ref — orders of magnitude faster on big repos.
-      def scan_since(ref = "HEAD~1", dir: ".", depth: :standard, stream: false)
+      def scan_since(ref = "HEAD~1", dir: ".", depth: :deep, stream: false)
         out, _, status = Open3.capture3("git", "-C", dir, "diff", "--name-only", "#{ref}...HEAD")
         return Result.err("git diff failed", category: :validation) unless status.success?
         paths = out.lines.map(&:strip).reject(&:empty?)


### PR DESCRIPTION
### Motivation
- Remove legacy shallow/standard/deep profiles and fake scan tiers so MASTER always performs a single, honest full scan by default. 
- Simplify scan dispatch logic and triad behavior to reduce cognitive load and eliminate profile-branching bugs. 
- Align configuration with the design principle that rule application depth should be explicit and cost-managed elsewhere (not via UI profiles). 

### Description
- Changed scanner entrypoints to default to `:deep` by updating `Scanner#scan`, `Scanner#scan_dir`, and `Scanner#scan_since` to use `depth: :deep`. 
- Collapsed `/scan` handling in `lib/master/command_registry/agent_commands.rb` to always collect targets and invoke the scanner in full-depth mode, removed profile resolution and rule-filtering plumbing, and simplified `format_scan_results`. 
- Removed workflow-level scan profile blocks (`scan_rules`, `principle_groups`, `scan_profiles`) from `data/workflow.yml` to stop encoding fake tiers in configuration. 
- Updated `data/standing_orders.yml` to reflect the new default triad command and wording (`triad .` / "full scan"), and adjusted `triad` invocation to pass the same target to `scan` and `sweep`. 

### Testing
- Ran syntax checks with `ruby -c lib/master/command_registry/agent_commands.rb` and `ruby -c lib/master/scan/scanner.rb`, both of which reported `Syntax OK`. 
- Verified repository-wide references for removed profile hooks with ripgrep and confirmed no syntax errors after the changes. 
- Attempted to run the canonical orientation `bundle exec ruby exe/master orient`, but the environment lacked a bundled git dependency checkout (`rb-edge-tts`), so full runtime orientation could not be executed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe056cad08832ab136a4fb15debc32)