### PR TITLE
Refine MASTER CLI presentation rhythm and prompt ergonomics

### DIFF
--- a/MASTER/lib/master/cli.rb
+++ b/MASTER/lib/master/cli.rb
@@ -40,7 +40,7 @@ module Master
       first_boot_bar
       puts @renderer.splash(@agent.model)
       puts @renderer.session_line(@session.name) if @session.name
-      print_repo_tree
+      print_repo_tree unless booted_before?
       process(initial_message) if initial_message
       @running = true
       repl_loop
@@ -78,6 +78,7 @@ module Master
         end
         unless state[:streamed]
           puts @renderer.speaker_tag
+          puts
         end
         print text
         $stdout.flush
@@ -107,10 +108,12 @@ module Master
         tokens = @session.token_est
         status = @renderer.status_row(uptime: @renderer.uptime, turns: @session.messages.size, violations: @violations)
         puts status if status
-        print @renderer.prompt_line(
+        prompt_lines = @renderer.prompt_line(
           @agent.model, @session.phase,
           last_ok: @last_ok, violations: @violations, tokens: tokens, cost: @session.cost
         )
+        puts prompt_lines.first
+        print prompt_lines.last
         line = safe_read_line
         break if line.nil?
         handle_repl_line(line)
@@ -178,8 +181,9 @@ module Master
       @violations = count_violations(result.value!)
       return if @violations.zero?
 
-      puts "\n#{@renderer.render("boot scan: #{@violations} violation(s)", mode: :dim)}"
-      print @renderer.prompt_line(@agent.model, @session.phase, last_ok: @last_ok, violations: @violations)
+      puts
+      puts @renderer.render("boot scan: #{@violations} violation(s)", mode: :dim)
+      puts
     rescue StandardError => e
       @bus&.publish("cli:warn", error: e.message)
     end
@@ -266,6 +270,13 @@ module Master
       nil
     end
 
+    def booted_before?
+      flag = File.join(@root, ".master", "booted_once")
+      File.exist?(flag)
+    rescue StandardError
+      false
+    end
+
     def first_boot_bar
       return unless $stdout.isatty
       flag = File.join(@root, ".master", "booted_once")
@@ -294,7 +305,9 @@ module Master
         if err.category == :shutdown
           exit_cli
         else
+          puts
           puts @renderer.render(err.message, mode: :error)
+          puts
         end
       end
     end

--- a/MASTER/lib/master/renderer.rb
+++ b/MASTER/lib/master/renderer.rb
@@ -68,24 +68,24 @@ module Master
     alias banner splash
 
     def prompt_line(model, phase, last_ok: true, violations: 0, tokens: nil, cost: nil)
-      branch = git_branch
-      bar = token_bar(tokens)
-      vbadge = violations > 0 ? @p.red("[#{violations}v] ") : ""
+      branch = git_branch || "detached"
+      usage = token_label(tokens)
+      model_str = @p.dim(short_model(model))
+      branch_str = @p.dim("branch:") + @p.red(branch)
+      vbadge = violations > 0 ? @p.red("[#{violations}v]") : @p.dim("[0v]")
+      phase_str = phase && phase.to_s != "idle" ? @p.dim(" #{phase}") : ""
       cost_str = cost_label(cost)
-      phase_str = phase && phase.to_s != "idle" ? @p.dim("{#{phase}} ") : ""
-      branch_str = branch ? "#{@p.dim("(")}#{@p.red(branch)}#{@p.dim(")")} " : ""
-      dollar = last_ok ? @p.bright_red("$") : @p.red("$")
-      "#{@p.bold.red("master")}@#{@p.red(short_model(model))} #{branch_str}#{phase_str}#{bar}#{cost_str}#{vbadge}#{dollar} "
+      prompt = last_ok ? @p.bold.red("master$") : @p.red("master$")
+      ["#{branch_str}  #{model_str}  ↖ #{usage}  #{cost_str} #{vbadge}#{phase_str}", prompt + " "]
     end
 
     def cost_label(cost)
-      return "" unless cost && cost > 0
       cents = (cost.to_f * 100).round(2)
-      @p.dim("\u00A2#{format('%.2f', cents)} ")
+      @p.dim("¢#{format('%.2f', cents)}")
     end
 
     def speaker_tag(name = "master")
-      "#{@p.dim("<")}#{@p.bold.red(name)}#{@p.dim(">")}"
+      "#{@p.dim("─")} #{@p.bold.red(name)} #{@p.dim("─")}" 
     end
 
     def status_row(uptime:, turns:, violations: 0)
@@ -98,17 +98,24 @@ module Master
       return "" unless tokens && tokens > 0
       budget = (@config["token_budget"] || TOKEN_BUDGET).to_i
       filled = ((tokens.to_f / budget) * BAR_CELLS).clamp(0, BAR_CELLS).round
-      @p.dim(("\u25B0" * filled) + ("\u25B1" * (BAR_CELLS - filled))) + " "
+      @p.dim(("▰" * filled) + ("▱" * (BAR_CELLS - filled))) + " "
+    end
+
+    def token_label(tokens)
+      return "0" unless tokens && tokens > 0
+      value = tokens.to_i
+      value >= 1000 ? format("%.1fk", value / 1000.0) : value.to_s
     end
 
     def render(content, mode: :plain)
+      text = beautify(content.to_s)
       case mode
-      when :error   then @p.red("err: #{content}")
-      when :success then @p.bright_red("ok: #{content}")
-      when :warning then @p.red("warn: #{content}")
-      when :dim     then @p.dim(content.to_s)
-      when :dmesg   then format_dmesg(content)
-      else content.to_s
+      when :error   then @p.red("err: #{text}")
+      when :success then @p.bright_red("ok: #{text}")
+      when :warning then @p.red("warn: #{text}")
+      when :dim     then @p.dim(text)
+      when :dmesg   then format_dmesg(text)
+      else text
       end
     end
 


### PR DESCRIPTION
### Motivation
- Reduce visual noise and improve scannability of the CLI by enforcing consistent vertical rhythm and simplifying the prompt layout.
- Surface useful metadata in a glanceable, non-wrapping status line and keep the input line minimal for narrow terminals.
- Make streamed conversational output and error blocks breathe consistently so operator attention is respected.

### Description
- Reworked prompt rendering to a compact two-line format where `prompt_line` now returns a metadata line and a minimal `master$` input line, improving narrow-terminal ergonomics (`lib/master/renderer.rb`, `lib/master/cli.rb`).
- Applied `beautify` output normalization across `render` modes so typographic cleanup (smart quotes, em dash, ellipsis) runs for `:plain`, `:error`, `:warning`, `:success`, `:dim`, and `:dmesg` outputs (`lib/master/renderer.rb`).
- Replaced the HTML-like speaker tag with a framed header (`─ master ─`) and ensured the speaker header is followed by a blank line before reply text to enforce vertical rhythm (`lib/master/renderer.rb`, `lib/master/cli.rb`).
- Added a compact token usage label helper and adjusted the token bar glyphs to `▰/▱`, tightened cost label formatting, and updated boot/session behavior to only print the repo tree on first boot to reduce repeat-session noise (`lib/master/renderer.rb`, `lib/master/cli.rb`).
- Tightened spacing around boot-scan and error output so summaries and errors always have surrounding blank lines (`lib/master/cli.rb`).

### Testing
- `ruby -c lib/master/renderer.rb` succeeded with no syntax errors.
- `ruby -c lib/master/cli.rb` succeeded with no syntax errors.
- Attempted to run `bundle exec ruby exe/master orient` per repository bootstrap guidance, but the environment failed due to missing Bundler checkout state for a git-sourced dependency (`rb-edge-tts`), so full runtime validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe0662e3f4832a807869727b7e0935)