### PR TITLE
Wire tools.yml into tool construction and model-tier LLM tool exposure

### DIFF
--- a/MASTER/lib/master/agent/llm_dispatcher.rb
+++ b/MASTER/lib/master/agent/llm_dispatcher.rb
@@ -9,7 +9,6 @@ module Master
     class LLMDispatcher
       COST_PER_TOKEN        = 0.000_015
       CACHE_WINDOW          = 4
-      VISITOR_ALLOWED_TOOLS = %w[AskLlm WebSearch].freeze
       NEMOTRON3_RE          = /nemotron-3/i.freeze
       LLAMA_NEMOTRON_RE     = /llama.*nemotron|nemotron.*llama/i.freeze
 
@@ -42,6 +41,8 @@ module Master
       def initialize(deps:, system_prompt:)
         @config, @cache, @circuit_breaker = deps.config, deps.cache, deps.circuit_breaker
         @tools, @bus, @system_prompt_proc = deps.tools, deps.bus, system_prompt
+        @model_router = deps.model_router
+        @tool_registry = load_tool_registry
       end
 
       def send_with_cache(selected_model, messages, system: nil, stream: false, &blk)
@@ -154,15 +155,28 @@ module Master
       end
 
       def build_llm_tools(visitor: false)
+        tier = @model_router&.tier_for_model(@config.model).to_s
         @tools.filter_map do |tool|
           wrapper = LLM_TOOL_MAP[tool.class]
           next nil unless wrapper
-          next nil if visitor && !VISITOR_ALLOWED_TOOLS.include?(tool.class.name.split("::").last)
+
+          tool_name = tool.class.name.split("::").last
+          meta = @tool_registry.fetch(tool_name, {})
+          next nil if visitor && meta["visitor"] != true
+          next nil if tier == "cheap" && meta["tier"] == "dangerous"
+
           wrapper.new(tool)
         end
       rescue StandardError => err
         @bus&.publish("agent:llm_tools_error", error: err.message)
         []
+      end
+
+      def load_tool_registry
+        path = File.join(Master::ROOT, "data", "tools.yml")
+        rows = Master.load_yaml(path)
+        return {} unless rows.is_a?(Array)
+        rows.each_with_object({}) { |row, out| out[row["name"].to_s] = row if row.is_a?(Hash) }
       end
     end
   end

--- a/MASTER/lib/master/builder.rb
+++ b/MASTER/lib/master/builder.rb
@@ -153,28 +153,48 @@ homeostat: infra[:homeostat])
     end
 
     def build_tools(root:, infra:)
+      definitions = load_tool_definitions(root)
+      definitions.filter_map do |defn|
+        next unless defn["default"] == true
+        build_tool_instance(defn["name"], root:, infra:)
+      end
+    end
+
+    def load_tool_definitions(root)
+      path = File.join(root, "data", "tools.yml")
+      data = Master.load_yaml(path)
+      return [] unless data.is_a?(Array)
+      data
+    end
+
+    def build_tool_instance(name, root:, infra:)
       bus = infra[:bus]
       undo = infra[:undo]
       governor = infra[:governor]
-      [
-        Tools::ReadFile.new(root:, undo:, event_bus: bus),
-        Tools::WriteFile.new(root:, undo:, governor:, event_bus: bus, diff_stager: infra[:diff_stager]),
-        Tools::StrReplace.new(root:, undo:, governor:, event_bus: bus, diff_stager: infra[:diff_stager]),
-        Tools::ListDir.new(root:, event_bus: bus),
-        Tools::SearchFiles.new(root:, event_bus: bus),
-        Tools::WebSearch.new(governor:, event_bus: bus),
-        Tools::Shell.new(root:, governor:, event_bus: bus),
-        Tools::BatchReplace.new(root:, governor:, event_bus: bus),
-        Tools::GitContext.new(root:, event_bus: bus),
-        Tools::AstEdit.new(root:, undo:, event_bus: bus),
-        Tools::Tree.new(root:, event_bus: bus),
-        Tools::SymbolLookup.new(code_index: infra[:code_index], event_bus: bus),
-        Tools::Clean.new(root:, governor:, event_bus: bus),
-        Tools::SearchKnowledge.new(root:, event_bus: bus),
-        Tools::FeedbackRecord.new(learnings: infra[:learnings]),
-        Tools::Postpro.new(root:, governor:, event_bus: bus),
-        Tools::Repligen.new(root:, governor:, event_bus: bus)
-      ]
+      case name.to_s
+      when "ReadFile" then Tools::ReadFile.new(root:, undo:, event_bus: bus)
+      when "WriteFile" then Tools::WriteFile.new(root:, undo:, governor:, event_bus: bus, diff_stager: infra[:diff_stager])
+      when "AtomicWrite" then Tools::AtomicWrite.new(root:, undo:, governor:, event_bus: bus, diff_stager: infra[:diff_stager])
+      when "StrReplace" then Tools::StrReplace.new(root:, undo:, governor:, event_bus: bus, diff_stager: infra[:diff_stager])
+      when "BatchReplace" then Tools::BatchReplace.new(root:, governor:, event_bus: bus)
+      when "AstEdit" then Tools::AstEdit.new(root:, undo:, event_bus: bus)
+      when "Tree" then Tools::Tree.new(root:, event_bus: bus)
+      when "ListDir" then Tools::ListDir.new(root:, event_bus: bus)
+      when "SearchFiles" then Tools::SearchFiles.new(root:, event_bus: bus)
+      when "SearchKnowledge" then Tools::SearchKnowledge.new(root:, event_bus: bus)
+      when "SymbolLookup" then Tools::SymbolLookup.new(code_index: infra[:code_index], event_bus: bus)
+      when "Shell" then Tools::Shell.new(root:, governor:, event_bus: bus)
+      when "GitContext" then Tools::GitContext.new(root:, event_bus: bus)
+      when "WebFetch" then Tools::WebFetch.new(governor:, event_bus: bus)
+      when "WebSearch" then Tools::WebSearch.new(governor:, event_bus: bus)
+      when "Clean" then Tools::Clean.new(root:, governor:, event_bus: bus)
+      when "Repligen" then Tools::Repligen.new(root:, governor:, event_bus: bus)
+      when "Postpro" then Tools::Postpro.new(root:, governor:, event_bus: bus)
+      when "FeedbackRecord" then Tools::FeedbackRecord.new(learnings: infra[:learnings])
+      else
+        bus&.publish("builder:tool_skipped", tool: name.to_s)
+        nil
+      end
     end
 
   end


### PR DESCRIPTION
### Motivation
- Make tool registration declarative so operators can tune tool visibility without editing Ruby code by wiring `data/tools.yml` into the builder. 
- Limit LLM-exposed tools based on model capability and visitor status to implement tier-aware safety (cheap models get no dangerous tools). 

### Description
- Replaced hardcoded tool list in `Master::Builder#build_tools` with YAML-driven construction that loads `data/tools.yml` and instantiates tools where `default: true` via `load_tool_definitions` and `build_tool_instance`.
- Added constructors for YAML-declared tools that were previously unwired (`AtomicWrite`, `WebFetch`, etc.) and publish `builder:tool_skipped` when an unknown tool name is encountered.
- Updated `Master::Agent::LLMDispatcher` to load the tool registry from `data/tools.yml` and use `ModelRouter#tier_for_model` to filter LLM-exposed tools by `tier` and `visitor` metadata (visitor sessions now honor YAML `visitor: true` and cheap-tier models exclude `dangerous` tools).
- Removed the hardcoded visitor whitelist constant and replaced it with metadata-driven checks against the loaded registry.

### Testing
- Ran Ruby syntax checks with `ruby -c` on the modified files (`MASTER/lib/master/builder.rb` and `MASTER/lib/master/agent/llm_dispatcher.rb`) and they passed.
- Attempted `bundle install` and `bundle exec ruby exe/master orient` in the container but they failed due to external bundler/gem fetching errors (`403 Forbidden` / locked bundler mismatch), so full integration/startup could not be executed here.
- No automated unit or integration test suite was executed beyond the syntax checks due to the environment dependency failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe082948e8832a8715fc43bfe77d40)