### PR TITLE
Refine error categorization and standardize scan findings

### DIFF
--- a/MASTER/lib/master/result.rb
+++ b/MASTER/lib/master/result.rb
@@ -2,9 +2,24 @@
 
 module Master
   class Result
-    def self.ok(value)                      = Ok.new(value)
-    def self.err(msg, category: :unknown)   = Err.new(msg, category)
-    def self.wrap(val)                      = val.respond_to?(:ok?) ? val : Ok.new(val)
+    CATEGORIES = {
+      validation: "input failed preconditions",
+      axiom_violation: "constitutional rule broken",
+      provider_error: "upstream model / network failure",
+      llm_failure: "LLM returned unusable output",
+      infrastructure: "system / disk / git error",
+      timeout: "operation exceeded deadline",
+      budget: "cost limit hit"
+    }.freeze
+
+    def self.ok(value) = Ok.new(value)
+
+    def self.err(msg, category: :unknown)
+      raise ArgumentError, "unknown category: #{category}" unless category == :unknown || CATEGORIES.key?(category)
+      Err.new(msg, category)
+    end
+
+    def self.wrap(val) = val.respond_to?(:ok?) ? val : Ok.new(val)
 
     class Ok
       attr_reader :value
@@ -27,7 +42,7 @@ module Master
         result = blk.call(@value)
         result.respond_to?(:ok?) ? result : Result.ok(result)
       rescue StandardError => e
-        Result.err("#{label || "stage"}: #{e.message}", category: :unknown)
+        Result.err("#{label || "stage"}: #{e.message}", category: :infrastructure)
       end
 
       def deconstruct_keys(_keys) = { value: @value }

--- a/MASTER/lib/master/scan/finding.rb
+++ b/MASTER/lib/master/scan/finding.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Master
+  module Scan
+    Finding = Data.define(:rule, :message, :line, :severity, :fix, :tags) do
+      def self.build(rule:, message:, line:, severity: :warning, fix: nil, tags: [])
+        new(rule:, message:, line:, severity:, fix:, tags:)
+      end
+
+      def [](key)
+        public_send(key)
+      end
+
+      def to_h
+        { rule:, message:, line:, severity:, fix:, tags: }
+      end
+    end
+  end
+end

--- a/MASTER/lib/master/scan/rule.rb
+++ b/MASTER/lib/master/scan/rule.rb
@@ -2,6 +2,8 @@
 
 module Master
   module Scan
+    require_relative "finding"
+
     class Rule
       EXT_LANG = {
         ".rb"      => "ruby",        ".rake"  => "ruby",   ".gemspec" => "ruby",
@@ -57,7 +59,7 @@ module Master
       protected
 
       def finding(line:, message:, fix: nil)
-        { rule: @id, message:, line:, severity: @severity, fix:, tags: @axiom_tags }
+        Finding.build(rule: @id, message:, line:, severity: @severity, fix:, tags: @axiom_tags)
       end
 
       def scan_lines(code, pattern, message:, fix: nil)

--- a/MASTER/lib/master/scan/rules/semantic_rule.rb
+++ b/MASTER/lib/master/scan/rules/semantic_rule.rb
@@ -3,6 +3,7 @@
 module Master
   module Scan
     module Rules
+      require_relative "../finding"
       # LLM review for rules whose violations resist lexical detection; deep depth only.
       # Rules with detect_semantic prompts in rules.yml are batched into one LLM call per file.
       class SemanticRule < Rule
@@ -72,8 +73,12 @@ module Master
             match_data = line.strip.match(/\A([A-Z_]+):(\d+):(.+)\z/)
             next unless match_data && @axioms.key?(match_data[1])
             rule_id = match_data[1]
-            { rule: rule_id.downcase, message: match_data[3].strip, line: match_data[2].to_i,
-              severity: @severity, fix: nil, tags: [rule_id.to_sym] }
+            Finding.build(rule: rule_id.downcase,
+                          message: match_data[3].strip,
+                          line: match_data[2].to_i,
+                          severity: @severity,
+                          fix: nil,
+                          tags: [rule_id.to_sym])
           end
         end
       end

--- a/MASTER/lib/master/scan/scanner.rb
+++ b/MASTER/lib/master/scan/scanner.rb
@@ -28,7 +28,7 @@ module Master
         Result.ok(findings)
       rescue StandardError => e
         @bus&.publish("scan:error", path:, error: e.message)
-        Result.err("scan failed: #{e.message}", category: :unknown)
+        Result.err("scan failed: #{e.message}", category: :infrastructure)
       end
 
       def scan_dir(dir, depth: :standard, glob: SCAN_GLOB, stream: false)
@@ -37,7 +37,7 @@ module Master
         parallel_each(paths) { |path, idx| results[idx] = scan_one(dir, path, depth, stream) }
         Result.ok(results)
       rescue StandardError => e
-        Result.err("scan_dir: #{e.message}", category: :unknown)
+        Result.err("scan_dir: #{e.message}", category: :infrastructure)
       end
 
       # Scan only files changed since git ref — orders of magnitude faster on big repos.
@@ -51,7 +51,7 @@ module Master
         parallel_each(paths) { |path, idx| results[idx] = scan_one(dir, path, depth, stream) }
         Result.ok(results)
       rescue StandardError => e
-        Result.err("scan_since: #{e.message}", category: :unknown)
+        Result.err("scan_since: #{e.message}", category: :infrastructure)
       end
 
       def add_rule(rule)
@@ -102,7 +102,7 @@ module Master
         [path, file_result]
       rescue StandardError => e
         @bus&.publish("scanner:thread_error", path:, error: e.message)
-        [path, Result.err(e.message, category: :unknown)]
+        [path, Result.err(e.message, category: :infrastructure)]
       end
 
       def stream_progress(dir, path, file_result)


### PR DESCRIPTION
### Motivation

- Prevent inconsistent error category usage and accidental bypass of rollback by introducing a canonical set of result categories and validating them at the call site. 
- Eliminate brittle, ad-hoc finding hashes emitted by scan rules and provide a single structured value object for rule findings. 
- Align scanner failure semantics so scan errors are classified as `:infrastructure` (retriable) rather than the catch‑all `:unknown`.

### Description

- Added `Master::Result::CATEGORIES` and validation in `Result.err` so unknown category symbols now raise `ArgumentError` and categories are centralized. 
- Adjusted `Ok#and_then` rescue fallback to emit `Result.err(..., category: :infrastructure)` to better reflect retriable system failures. 
- Introduced `Master::Scan::Finding` (a `Data` value object with `build`, `[]`, and `to_h`) and updated `Rule#finding` and the `SemanticRule` parser to emit `Finding` instances instead of raw hashes. 
- Reclassified scanner rescue paths (`scan`, `scan_dir`, `scan_since`, and threaded worker fallback) to return `Result.err(..., category: :infrastructure)`.

### Testing

- Ran syntax checks with `ruby -c` against modified files (`lib/master/result.rb`, `lib/master/scan/rule.rb`, `lib/master/scan/scanner.rb`, `lib/master/scan/rules/semantic_rule.rb`) and they all reported `Syntax OK`.
- Attempted `bundle exec ruby exe/master orient` but it could not run in this environment due to missing bundled git dependency checkout (`rb-edge-tts`), so full runtime integration tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe09ee1610832aafcfc8ebc87f5481)