### PR TITLE
Add per-turn SearchFiles caching, fix LLM wrapper, and adaptive sweep depth

### DIFF
--- a/MASTER/lib/master/sweep.rb
+++ b/MASTER/lib/master/sweep.rb
@@ -10,6 +10,8 @@ module Master
   # Full-codebase refactor to convergence; stops on delta/oscillation/stall (arxiv:2602.21833).
   class Sweep
     MAX_CYCLES         = 16
+    SMALL_CHANGE_LINES = 5
+    MEDIUM_CHANGE_LINES = 30
     CONVERGE_THRESHOLD = 0.05
     CONVERGE_WINDOW    = 2
     RENAME_WINDOW    = 3
@@ -70,6 +72,7 @@ circuit\sopen|retry\sin|llm_request)\b
       @converge_window    = cfg.fetch("converge_window",    CONVERGE_WINDOW)
       @map            = build_codebase_map
       @prompts        = load_prompts
+      sweep_types     = select_types(target, types)
       violation_history = []
       converge_streak   = 0
       init_cycle_log
@@ -83,7 +86,7 @@ circuit\sopen|retry\sin|llm_request)\b
 
         @bus&.publish("sweep:cycle", cycle:, target:)
 
-        collect_files(target, types).each do |path|
+        collect_files(target, sweep_types).each do |path|
           rel    = path.delete_prefix("#{@root}/")
           before = violations_in(path)
           src    = File.read(path, encoding: "UTF-8")
@@ -126,6 +129,26 @@ circuit\sopen|retry\sin|llm_request)\b
     end
 
     private
+
+    def select_types(target, fallback_types)
+      changed = changed_line_count(target)
+      return %i[rb sh] if changed < SMALL_CHANGE_LINES
+      return %i[rb sh yml] if changed <= MEDIUM_CHANGE_LINES
+      fallback_types
+    end
+
+    def changed_line_count(target)
+      rel = target.to_s == @root ? nil : target.delete_prefix(@root + "/")
+      cmd = ["git", "-C", @root, "diff", "--numstat", "HEAD"]
+      cmd << "--" << rel if rel && !rel.empty?
+      out, = Open3.capture2(*cmd)
+      out.lines.sum do |line|
+        a, d, = line.split("	", 3)
+        a.to_i + d.to_i
+      end
+    rescue StandardError
+      MEDIUM_CHANGE_LINES
+    end
 
     def evaluate_rewrite(rel, src, before, cycle)
       abs = File.join(@root, rel)

--- a/MASTER/lib/master/tools/llm.rb
+++ b/MASTER/lib/master/tools/llm.rb
@@ -75,7 +75,7 @@ module Master
         def initialize(tool) = @tool = tool
 
         def execute(pattern:, path: ".", context: 2)
-          result = @tool.call(pattern: pattern.to_s, path: path.to_s, context: context.to_i)
+          result = @tool.call(pattern: pattern.to_s, glob: path.to_s, context_lines: context.to_i)
           result.ok? ? result.value! : "Error: #{result.message}"
         end
       end

--- a/MASTER/lib/master/tools/search_files.rb
+++ b/MASTER/lib/master/tools/search_files.rb
@@ -12,16 +12,23 @@ module Master
       def initialize(root:, event_bus: nil)
         @root = File.realpath(root)
         @bus  = event_bus
+        @cache = {}
+      end
+
+      def reset!
+        @cache.clear
       end
 
       def call(pattern:, glob: "**/*", context_lines: 2)
+        key = [pattern, glob, context_lines]
+        return @cache[key] if @cache.key?(key)
         begin
           re = Regexp.new(pattern)
         rescue RegexpError
           return Result.err("invalid pattern: #{pattern}", category: :validation)
         end
 
-        paths   = Dir.glob(File.join(@root, glob)).select { |p| File.file?(p) }
+        paths   = cached_paths(glob)
         results = []
 
         paths.each do |path|
@@ -35,16 +42,29 @@ module Master
             ctx    = lines[start..finish].each_with_index.map { |l, i| "#{start + i + 1}:#{l}" }.join
             rel    = path.delete_prefix(@root + "/")
             results << "#{rel}:#{idx + 1}\n#{ctx}"
-            return Result.ok(results.join("\n---\n") + "\n[...truncated]") if results.size >= MAX_RESULTS
+            if results.size >= MAX_RESULTS
+              out = Result.ok(results.join("\n---\n") + "\n[...truncated]")
+              @cache[key] = out
+              return out
+            end
           end
         end
 
-        Result.ok(results.empty? ? "(no matches)" : results.join("\n---\n"))
+        out = Result.ok(results.empty? ? "(no matches)" : results.join("\n---\n"))
+        @cache[key] = out
+        out
       rescue StandardError => e
         Result.err("search_files: #{e.message}", category: :unknown)
       end
 
       private
+
+      def cached_paths(glob)
+        list_key = [:glob, glob]
+        return @cache[list_key] if @cache.key?(list_key)
+        paths = Dir.glob(File.join(@root, glob)).select { |p| File.file?(p) }
+        @cache[list_key] = paths
+      end
 
       def binary_file?(path)
         sample = begin; File.read(path, BINARY_SAMPLE_BYTES); rescue StandardError; ""; end


### PR DESCRIPTION
### Motivation
- Reduce redundant disk I/O and repeated file reads during multi-step LLM tool chains by caching `SearchFiles` results per chat turn. 
- Ensure the LLM-facing `SearchFiles` wrapper forwards the correct parameters to the underlying tool so tool calls behave deterministically. 
- Make `/sweep` latency proportional to change size by avoiding full deep scans for tiny edits.

### Description
- Added a per-turn in-memory cache and `reset!` hook to `Master::Tools::SearchFiles` so identical `call` inputs and glob expansions are deduplicated; file: `MASTER/lib/master/tools/search_files.rb`.
- Updated `Master::Tools::LLM::SearchFiles` to forward `glob` and `context_lines` to the underlying tool instead of incorrect parameter names; file: `MASTER/lib/master/tools/llm.rb`.
- Implemented adaptive sweep file-type selection in `Master::Sweep` by adding `SMALL_CHANGE_LINES` and `MEDIUM_CHANGE_LINES` thresholds and a `changed_line_count` helper that uses `git --numstat` to pick a smaller `types` set for small changes; file: `MASTER/lib/master/sweep.rb`.
- Integrated caching behavior with the existing agent lifecycle via the `reset!` hook that the `Agent` already calls at the start of each chat turn.

### Testing
- Ran Ruby syntax checks: `ruby -c MASTER/lib/master/tools/search_files.rb` and it succeeded.
- Ran Ruby syntax checks: `ruby -c MASTER/lib/master/tools/llm.rb` and it succeeded.
- Ran Ruby syntax checks: `ruby -c MASTER/lib/master/sweep.rb` and it succeeded.
- Attempted `bundle exec ruby exe/master orient` but it failed in this environment due to a missing bundled git dependency checkout (`rb-edge-tts`), so the orientation bootstrap could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe0ee0ddc8832ab04d3e543e20c4cb)