### PR TITLE
Replace chat view with minimalist particle-driven single-page UI

### DIFF
--- a/MASTER/web/app/views/chat/index.html.erb
+++ b/MASTER/web/app/views/chat/index.html.erb
@@ -1,2395 +1,384 @@
 <!DOCTYPE html>
-<html lang="ms">
+<html lang="en">
 <head>
-  <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover"/>
-  <meta name="mobile-web-app-capable" content="yes"/>
-  <meta name="color-scheme" content="dark"/>
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
-  <title>MASTER &middot; <%= @model %></title>
-  <meta name="theme-color" content="#000000"/>
-  <link rel="preconnect" href="https://fonts.googleapis.com"/>
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400;500&family=VT323&family=Major+Mono+Display&display=swap"/>
-<style>
-  @layer base, components, utilities;
-
-  @layer base{
-  :root{
-    --safe-top:env(safe-area-inset-top,0px);
-    --safe-right:env(safe-area-inset-right,0px);
-    --safe-bottom:env(safe-area-inset-bottom,0px);
-    --safe-left:env(safe-area-inset-left,0px);
-    --pitch:#0a0c0a;
-    --iron:#1f221d;
-    --bone:#cdc5b6;
-    --rust:#a0522d;
-    --brine:#4a7d80;
-    --amber:#d6a13f;
-    --grit:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 1 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
-    --ease:cubic-bezier(.2,.8,.2,1);
-  }
-  html,body{
-    margin:0;
-    height:100%;
-    background:var(--pitch);
-    color:var(--bone);
-    font:16px/1.5 "VT323","Roboto Mono",ui-monospace,Menlo,Monaco,Consolas,monospace;
-    -webkit-font-smoothing:none;
-    -moz-osx-font-smoothing:grayscale;
-    font-smooth:never;
-    text-rendering:optimizeSpeed;
-    overflow:hidden;
-    touch-action:none;
-  }
-  body::before{
-    content:"";
-    position:fixed;inset:0;
-    z-index:9998;pointer-events:none;
-    background:radial-gradient(ellipse at center,transparent 55%,rgba(0,0,0,.22) 100%);
-  }
-  body::after{
-    content:"";
-    position:fixed;inset:0;
-    z-index:9999;pointer-events:none;
-    background-image:var(--grit);
-    opacity:.045;mix-blend-mode:overlay;
-  }
-  *{transition-timing-function:var(--ease);}
-  }/* end @layer base */
-
-@layer components{
-/* Low-end CSS orb
- — GPU compositor only, zero JS render cost */
-    #orb-css{
-      position:fixed;
-      left:50%;top:50%;
-      width:min(58vw,58vh);height:min(58vw,58vh);
-      border-radius:50%;
-      transform:translate(-50%,-50%) translateZ(0);
-      background:radial-gradient(circle at 38% 35%,#6b2018,#1a0505 55%,#020000);
-      box-shadow:0 0 60px 8px rgba(80,10,10,0.35),inset 0 0 40px rgba(0,0,0,0.7);
-      animation:orb-idle 4s ease-in-out infinite;
-      will-change:transform,opacity;
-      pointer-events:none;
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#000000">
+  <title>MASTER</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #000;
+      --fg: #fff;
+      --dim: rgba(255,255,255,0.3);
+      --hairline: rgba(255,255,255,0.12);
+      --accent: 255, 255, 255;
+      --think-accent: 200, 220, 255;
+      --max-line-width: 60ch;
+      --pad: 1.5rem;
     }
-    @keyframes orb-idle{
-      0%,100%{transform:translate(-50%,-50%) scale(1) translateZ(0);opacity:.65;}
-      50%     {transform:translate(-50%,-50%) scale(1.06) translateZ(0);opacity:.85;}
-    }
-    #orb-css.speaking{
-      background:radial-gradient(circle at 38% 35%,#b03030,#3d1010 55%,#020000);
-      box-shadow:0 0 90px 20px rgba(160,20,20,0.55),inset 0 0 35px rgba(0,0,0,0.4);
-      animation:orb-speak .55s ease-in-out infinite;
-    }
-    @keyframes orb-speak{
-      0%,100%{transform:translate(-50%,-50%) scale(1) translateZ(0);}
-      30%     {transform:translate(-50%,-50%) scale(1.1) translateZ(0);}
-      70%     {transform:translate(-50%,-50%) scale(.96) translateZ(0);}
-    }
-    #orb-css.processing{
-      background:radial-gradient(circle at 38% 35%,#6b4008,#1e0e02 55%,#020000);
-      box-shadow:0 0 70px 12px rgba(90,55,5,0.45),inset 0 0 40px rgba(0,0,0,0.6);
-      animation:orb-think 1.3s ease-in-out infinite;
-    }
-    @keyframes orb-think{
-      0%,100%{transform:translate(-50%,-50%) scale(1) translateZ(0);opacity:.6;}
-      50%     {transform:translate(-50%,-50%) scale(1.05) translateZ(0);opacity:1;}
+    html, body { height: 100%; background: var(--bg); color: var(--fg); }
+    body {
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      font-size: 16px;
+      line-height: 1.5;
+      overflow: hidden;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      user-select: none;
     }
 
-    #swarm-iframe{
-      position:fixed;
-      inset:0;
-      width:100dvw;
-      height:100dvh;
-      display:block;
-      border:0;
-      background:#020000;
-      touch-action:none;
-      cursor:pointer;
+    canvas#particles {
+      position: fixed; inset: 0; z-index: 0;
     }
 
-    #status{
-      position:fixed;
-      top:calc(10px + var(--safe-top));
-      right:calc(10px + var(--safe-right));
-      z-index:95;
-      user-select:none;
-      font-size:14px;
-      color:#333;
-      cursor:pointer;
-      padding:12px;
-      transition:color 0.3s;
+    main {
+      position: relative; z-index: 1;
+      display: flex; flex-direction: column; height: 100%;
     }
 
-    #status.think{color:#662222;}
-    #status.speak{color:#993333;}
-    #status.processing{color:#7a3a0a;animation:pulse-status 1.2s ease-in-out infinite;}
-    @keyframes pulse-status{0%,100%{opacity:1;}50%{opacity:0.3;}}
-
-    #ui{
-      position:fixed;
-      right:calc(12px + var(--safe-right));
-      bottom:calc(10px + var(--safe-bottom));
-      color:#2a0808;
-      font:9px/1.1 ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;
-      text-transform:uppercase;
-      letter-spacing:.28em;
-      white-space:nowrap;
-      pointer-events:none;
-      user-select:none;
-      text-align:right;
-      opacity:.5;
-      transition:opacity 0.6s, color 0.3s;
+    #messages {
+      flex: 1; overflow-y: auto; padding: var(--pad);
+      display: flex; flex-direction: column; gap: 1rem;
+      scroll-behavior: smooth;
     }
-    #ui.highlight{opacity:1;color:#993333;}
-
-    #ui-dots{
-      display:inline-block;
-      width:3ch;
-      text-align:left;
+    .message {
+      max-width: var(--max-line-width);
+      animation: fadeSlide 0.3s ease-out;
     }
-
-    #input-field{
-      position:fixed;
-      bottom:15vh;
-      left:50%;
-      transform:translateX(-50%);
-      width:0;
-      opacity:0;
-      transition:width 0.3s ease-out, opacity 0.2s ease;
-      z-index:10;
+    .message.user { align-self: flex-end; }
+    .message.assistant {
+      align-self: flex-start;
+      border-left: 1px solid var(--hairline);
+      padding-left: 1rem;
+    }
+    .message.assistant.thinking {
+      border-left-color: rgb(var(--think-accent));
+      transition: border-color 0.6s;
+    }
+    .message .text {
+      white-space: pre-wrap;
+      line-height: 1.6;
+      color: var(--fg);
+    }
+    .message .meta {
+      font-size: 0.75rem;
+      color: var(--dim);
+      margin-top: 0.25rem;
+      display: none;
     }
 
-    #input-field.active{
-      width:70vw;
-      max-width:500px;
-      opacity:1;
+    @keyframes fadeSlide {
+      from { opacity: 0; transform: translateY(0.5rem); }
+      to   { opacity: 1; transform: translateY(0); }
     }
 
-    #input-field{
-      display:flex;
-      align-items:baseline;
-      gap:10px;
-      padding:12px 14px;
-      background:rgba(2,0,0,0.65);
-      border:1px solid #1a0606;
-      border-radius:4px;
-      backdrop-filter:blur(6px);
+    #input-area {
+      flex-shrink: 0;
+      border-top: 1px solid var(--hairline);
+      padding: 0.5rem var(--pad);
+      display: flex; align-items: center;
+      background: var(--bg);
+    }
+    #input-line {
+      flex: 1;
+      background: transparent; border: none; outline: none;
+      color: var(--fg);
+      font: inherit; font-size: 1rem;
+      caret-color: var(--fg);
+      padding: 0.5rem 0;
+      resize: none;
+    }
+    #input-line::placeholder { color: var(--dim); }
+    button { display: none; } /* no buttons */
+
+    @media (max-width: 600px) {
+      :root { --pad: 1rem; }
+      body { font-size: 15px; }
     }
 
-    #prompt-glyph{
-      font-family:'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-      font-size:16px;
-      font-weight:500;
-      color:#993333;
-      user-select:none;
-      letter-spacing:0;
-      animation:prompt-breathe 2.4s ease-in-out infinite;
-    }
-    @keyframes prompt-breathe{0%,100%{opacity:.6;}50%{opacity:1;}}
-    @keyframes token-fade{0%,100%{opacity:1;}50%{opacity:.85;}}
-    .entry.streaming{animation:token-fade 1.6s ease-in-out infinite;}
-    @keyframes entry-rise{from{opacity:0;transform:translateY(2px);}to{opacity:1;transform:none;}}
-    .entry{animation:entry-rise .32s ease-out both;}
-    .entry:nth-child(2n){animation-delay:60ms;}
-    .entry:nth-child(3n){animation-delay:80ms;}
-    @media(prefers-reduced-motion:reduce){#prompt-glyph,.entry,.entry.streaming{animation:none;}}
-
-    #input-field input{
-      flex:1;
-      min-width:0;
-      background:transparent;
-      border:none;
-      color:#dcdcdc;
-      font-family:'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-      font-size:16px;
-      font-weight:400;
-      letter-spacing:0;
-      padding:0;
-      outline:none;
-      text-align:left;
-      caret-color:#993333;
-    }
-
-    #input-field input::placeholder{
-      color:#444;
-      font-style:normal;
-    }
-
-    #attach-btn{
-      background:none;
-      border:none;
-      color:#333;
-      cursor:pointer;
-      font-size:18px;
-      padding:0 0 0 6px;
-      vertical-align:middle;
-      transition:color 0.2s, opacity 0.3s;
-      opacity:0;
-    }
-    #input-field.active #attach-btn{opacity:1;}
-    #attach-btn:hover,#attach-btn.has-file{color:#888;}
-    #attach-label{
-      display:block;
-      font-size:10px;
-      color:#555;
-      text-align:center;
-      letter-spacing:0.08em;
-      margin-top:4px;
-      overflow:hidden;
-      white-space:nowrap;
-      text-overflow:ellipsis;
-    }
-    #overlay{
-      position:fixed;
-      inset:0;
-      display:flex;
-      flex-direction:column;
-      align-items:center;
-      justify-content:center;
-      gap:28px;
-      background:transparent;
-      cursor:pointer;
-      user-select:none;
-      z-index:1000;
-      touch-action:manipulation;
-      text-align:center;
-      padding:32px;
-      opacity:1;
-      transition:opacity 0.8s ease;
-    }
-
-    #overlay.ack{opacity:0;pointer-events:none;}
-    #overlay[hidden]{display:none;}
-
-    #overlay h1{
-      margin:0;
-      font-family:"Major Mono Display","VT323",ui-monospace,monospace;
-      font-size:clamp(20px,5vw,34px);
-      font-weight:400;
-      color:#666;
-      letter-spacing:.18em;
-      text-transform:uppercase;
-      transition:transform .12s steps(2);
-    }
-    #overlay h1:hover{transform:translate(1px,-1px);}
-    @media(prefers-reduced-motion:reduce){#overlay h1{transition:none;}#overlay h1:hover{transform:none;}}
-
-    #overlay .hint{
-      font-size:10px;
-      color:#222;
-      letter-spacing:.15em;
-      animation:overlay-pulse 3s ease-in-out infinite;
-    }
-
-    @keyframes overlay-pulse{0%,100%{opacity:.4;}50%{opacity:.8;}}
-
-    #chat-log{
-      display:none;
-      position:fixed;
-      inset:0;
-      z-index:200;
-      background:rgba(0,0,0,.92);
-      overflow-y:auto;
-      padding:48px 5vw 80px;
-      font:13px/1.6 ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;
-      color:#aaa;
-    }
-    #chat-log.open{display:block;}
-    #chat-log .entry{margin-bottom:1.4em;white-space:pre-wrap;word-break:break-word;}
-    #chat-log .entry.user{color:#ccc;}
-    #chat-log .entry.master{color:#777;}
-    #chat-log .entry.user::before{content:'> ';color:#555;}
-    #chat-log .entry.master::before{content:': ';color:#444;}
-    #chat-log .entry.system{color:#666;}
-    #chat-log .entry.system::before{content:'! ';color:#a0522d;}
-    #chat-log .entry.tool::before{content:'* ';color:#4a7d80;}
-    body{cursor:default;}
-    #chat-log{cursor:text;}
-    #status{cursor:ns-resize;}
-    #input-field input{cursor:text;}
-    button,a,[role=button]{cursor:pointer;}
-    #tab-hint{
-      position:fixed;top:12px;right:16px;
-      font-size:10px;color:#333;letter-spacing:.1em;pointer-events:none;
-    }
-    #sidebar{
-      position:fixed;top:0;right:0;
-      width:min(280px,85vw);height:100dvh;
-      background:#0a0202;border-left:1px solid #1a0606;
-      z-index:400;overflow-y:auto;padding:16px;box-sizing:border-box;
-      transform:translateX(100%);transition:transform 0.2s ease;
-      font-size:11px;color:#555;letter-spacing:.05em;
-    }
-    #sidebar.open{transform:translateX(0);}
-    #sidebar h3{color:#662222;font-size:10px;letter-spacing:.15em;text-transform:uppercase;margin:12px 0 4px;}
-    #sidebar .row{display:flex;justify-content:space-between;padding:2px 0;border-bottom:1px solid #0f0303;}
-    #sidebar .ok{color:#2a6a2a;}
-    #sidebar .err{color:#8a1a1a;}
-    }/* end @layer components */
+    /* subtle scrollbar */
+    #messages::-webkit-scrollbar { width: 4px; }
+    #messages::-webkit-scrollbar-thumb { background: var(--hairline); border-radius: 2px; }
   </style>
-  <%= csrf_meta_tags %>
 </head>
 <body>
-  <ol id="chat-log"><small id="tab-hint">TAB TO CLOSE</small></ol>
-  <section id="status">◉</section>
-  <aside id="sidebar" aria-label="System status">
-    <h3>Circuit Breakers</h3><div id="sb-breakers"></div>
-    <h3>Session Budget</h3><div id="sb-budget"></div>
-    <h3>Phase</h3><div id="sb-phase"></div>
-    <h3>Standing Orders</h3><div id="sb-orders"></div>
-  </aside>
-  <section id="ui"><span id="ui-label">MASTER</span><span id="ui-dots"></span></section>
-
-  <section id="input-field">
-    <span id="prompt-glyph">master ❯</span>
-    <input type="text" placeholder="ask, ideate, /scan, /sweep…" autocomplete="off" maxlength="512" aria-label="Message">
-    <button id="attach-btn" title="Attach image">+</button>
-    <input type="file" id="file-input" accept="image/*,text/*,.pdf" hidden>
-    <span id="attach-label"></span>
-  </section>
-
-  <iframe id="swarm-iframe" src="/swarm.html" allow="microphone"></iframe>
-
-  <section id="overlay" role="dialog" aria-modal="true">
-    <h1>MASTER</h1>
-    <p class="hint">tap to begin</p>
-  </section>
+  <canvas id="particles"></canvas>
+  <main>
+    <div id="messages"></div>
+    <div id="input-area">
+      <input id="input-line" type="text" placeholder="…" autofocus autocomplete="off" autocapitalize="off" />
+    </div>
+  </main>
 
   <script>
-    "use strict";
-    (function(){
-      const h=new Date().getHours();
-      const tint=(h<6||h>=21)?'sepia(.06) hue-rotate(-8deg) brightness(.94)'
-                :(h<10)?'sepia(.05) brightness(1.02)'
-                :(h>=17)?'sepia(.08) hue-rotate(-4deg) brightness(.97)'
-                :'none';
-      if(tint!=='none') document.documentElement.style.filter=tint;
-    })();
-    const swarmIframe=document.getElementById('swarm-iframe');
-    const statusEl=document.getElementById('status');
-    const uiLabel=document.getElementById('ui-label');
-    const uiDots=document.getElementById('ui-dots');
-    const inputField=document.getElementById('input-field');
-    let _overlayJustDismissed=false;
-    const input=inputField.querySelector('input[type=text]');
-    const fileInput=document.getElementById('file-input');
-    const attachBtn=document.getElementById('attach-btn');
-    const attachLabel=document.getElementById('attach-label');
-    const chatLog=document.getElementById('chat-log');
-    const overlay=document.getElementById('overlay');
-    const SpeechRecognition=window.SpeechRecognition||window.webkitSpeechRecognition;
-    const MASTER_TOKEN='x';
-    const COMPAT_LABEL="master or+rep";
-    const TTS_BACKEND_KEY="master_tts_backend";
+    // ─── Particle system ──────────────────────────────────────────────
+    const canvas = document.getElementById('particles');
+    const ctx = canvas.getContext('2d');
+    let width, height;
+    let particles = [];
+    const PARTICLE_COUNT = 2500;
+    const FACE_POINTS = []; // will hold outline coords for brief face display
 
-    // Chat log helpers with localStorage persistence
-    const CHAT_KEY='m2_chat';
-    const MAX_STORED=50;
-    const logAppend=(role,text)=>{
-      const e=document.createElement('div');
-      e.className=`entry ${role}`;
-      if(role==='master'){e.innerHTML=renderMd(text);}else{e.textContent=text;}
-      chatLog.appendChild(e);
-      chatLog.scrollTop=chatLog.scrollHeight;
-      // Persist
-      try{
-        const stored=JSON.parse(localStorage.getItem(CHAT_KEY)||'[]');
-        stored.push({r:role,t:text});
-        if(stored.length>MAX_STORED) stored.splice(0,stored.length-MAX_STORED);
-        localStorage.setItem(CHAT_KEY,JSON.stringify(stored));
-      }catch(_){}
-    };
-    // Restore chat history on load
-    try{
-      const stored=JSON.parse(localStorage.getItem(CHAT_KEY)||'[]');
-      for(const m of stored){
-        const e=document.createElement('div');
-        e.className=`entry ${m.r}`;
-        e.textContent=m.t;
-        chatLog.appendChild(e);
-      }
-      chatLog.scrollTop=chatLog.scrollHeight;
-    }catch(_){}
-    document.addEventListener('keydown',e=>{
-      if(e.key==='Tab'){e.preventDefault();chatLog.classList.toggle('open');}
-    });
-    let pullStartY=0,pullStartX=0,pullActive=false;
-    window.addEventListener('touchstart',e=>{
-      const touch=e.touches[0];
-      if(touch.clientY<80&&!chatLog.classList.contains('open')){pullStartY=touch.clientY;pullStartX=touch.clientX;pullActive=true;}
-      else pullActive=false;
-    },{passive:true});
-    window.addEventListener('touchend',e=>{
-      if(!pullActive) return;
-      const dy=e.changedTouches[0].clientY-pullStartY;
-      const dx=Math.abs(e.changedTouches[0].clientX-pullStartX);
-      if(dy>60&&dx<40){chatLog.classList.add('open');haptic(10);}
-      pullActive=false;
-    },{passive:true});
-
-const csrfToken = () => {
-  const meta = document.querySelector('meta[name="csrf-token"]');
-  return meta ? meta.getAttribute('content') : '';
-};
-
-const renderMd = raw => {
-  let t = String(raw).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-  t = t.replace(/```[\w]*\n?([\s\S]*?)```/g, '<pre><code>$1</code></pre>');
-  t = t.replace(/`([^`\n]+)`/g, '<code>$1</code>');
-  t = t.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>');
-  t = t.replace(/\*([^*\n]+)\*/g, '<em>$1</em>');
-  t = t.replace(/\n/g, '<br>');
-  return t;
-};
-
-    // responses stream from POST /chat/message
-
-    let pendingFile=null;
-
-    attachBtn.addEventListener('click',e=>{e.stopPropagation();fileInput.click();});
-    fileInput.addEventListener('change',()=>{
-      const f=fileInput.files[0];
-      if(f){
-        pendingFile=f;
-        attachBtn.classList.add('has-file');
-        attachLabel.textContent=f.name;
-      }else{
-        pendingFile=null;
-        attachBtn.classList.remove('has-file');
-        attachLabel.textContent='';
-      }
-    });
-
-    let W,H,S;
-    const resize=()=>{
-      W=window.innerWidth;
-      H=window.innerHeight;
-      S=Math.min(W,H)/100;
-    };
-    window.addEventListener('resize',resize);
-    window.addEventListener('orientationchange',()=>setTimeout(resize,100));
+    function resize() {
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = width;
+      canvas.height = height;
+    }
+    window.addEventListener('resize', resize);
     resize();
 
-    let audioCtx,analyser,dataArray;
-    let audioLevel=0;
-// master:tilt-reveal — chrome via device motion/orientation
-if (window.DeviceOrientationEvent) {
-  let lastTilt = 0;
-  window.addEventListener('deviceorientation', e => {
-    const now = Date.now(); if (now - lastTilt < 600) return;
-    const sb = document.getElementById('sidebar');
-    if (Math.abs(e.gamma||0) > 55 && sb) { sb.classList.toggle('open'); lastTilt = now; }
-  });
-}
-if (window.DeviceMotionEvent) {
-  let lastShake = 0;
-  window.addEventListener('devicemotion', e => {
-    const a = e.accelerationIncludingGravity; if (!a) return;
-    const m = Math.hypot(a.x||0, a.y||0, a.z||0);
-    const now = Date.now();
-    if (m > 28 && now - lastShake > 1200) {
-      const cl = document.getElementById('chat-log');
-      if (cl) cl.classList.toggle('open');
-      lastShake = now;
+    // Generate wireframe face points (a stylized geometric face outline)
+    function generateFaceOutline() {
+      const cx = width * 0.5, cy = height * 0.45;
+      const scale = Math.min(width, height) * 0.15;
+      const points = [];
+      // simple face: two eyes, nose line, mouth
+      // left eye
+      for (let a = 0; a < Math.PI * 2; a += 0.3) {
+        points.push([cx - scale * 1.2 + Math.cos(a)*scale*0.4, cy - scale*0.3 + Math.sin(a)*scale*0.25]);
+      }
+      // right eye
+      for (let a = 0; a < Math.PI * 2; a += 0.3) {
+        points.push([cx + scale * 1.2 + Math.cos(a)*scale*0.4, cy - scale*0.3 + Math.sin(a)*scale*0.25]);
+      }
+      // nose bridge
+      for (let t = 0; t <= 1; t += 0.1) {
+        points.push([cx + (t-0.5)*scale*0.3, cy - scale*0.3 + t*scale*0.8]);
+      }
+      // mouth
+      for (let a = 0; a < Math.PI; a += 0.2) {
+        points.push([cx + Math.cos(a)*scale*0.7, cy + scale*0.7 + Math.sin(a)*scale*0.15]);
+      }
+      return points;
     }
-  });
-}
-// Pre-load voices immediately so they are available synchronously on first gesture.
-    let _cachedVoices=[];
-    if('speechSynthesis' in window){
-      _cachedVoices=window.speechSynthesis.getVoices();
-      window.speechSynthesis.addEventListener('voiceschanged',()=>{
-        _cachedVoices=window.speechSynthesis.getVoices();
-      });
-    }
-    let speechPulse=0;
-    // Echo guard: remember recent TTS phrases so mic-loopback doesn't get re-sent to LLM.
-    const _recentTts=[]; // [{text, until}]
-    const _ttsRemember=(text)=>{
-      const t=String(text||'').toLowerCase().replace(/[^\p{L}\p{N}\s]/gu,' ').replace(/\s+/g,' ').trim();
-      if(!t) return;
-      _recentTts.push({t,until:Date.now()+25000});
-      while(_recentTts.length&&_recentTts[0].until<Date.now()) _recentTts.shift();
-    };
-    const _ttsEchoes=(heard)=>{
-      const h=String(heard||'').toLowerCase().replace(/[^\p{L}\p{N}\s]/gu,' ').replace(/\s+/g,' ').trim();
-      if(h.length<3) return false;
-      const now=Date.now();
-      for(const r of _recentTts){
-        if(r.until<now) continue;
-        if(r.t.includes(h)||h.includes(r.t)) return true;
-        const hw=new Set(h.split(' '));const rw=r.t.split(' ');
-        let m=0;for(const w of rw) if(hw.has(w)) m++;
-        if(rw.length&&m/rw.length>=0.6) return true;
+    FACE_POINTS.push(...generateFaceOutline());
+
+    class Particle {
+      constructor() {
+        this.reset();
       }
-      return false;
-    };
-    // Sentence queue for server TTS — prevents overlapping BufferSource playback.
-    const _ttsQueue=[]; let _ttsBusy=false; let _ttsCurrent=null;
-
-    // P5: affect tag → voice/style swap. Stream may emit `[mood:calm]`, `[mood:urgent]` etc.
-    const AFFECT_MAP={
-      calm:    {voice:'yasmin', style:'slow'},
-      urgent:  {voice:'steffan',style:'normal'},
-      playful: {voice:'yasmin', style:'natural'},
-      sober:   {voice:'ryan',   style:'slow'},
-      warm:    {voice:'yasmin', style:'natural'},
-      grim:    {voice:'osman',  style:'deep'}
-    };
-    const _extractAffect=(s)=>{
-      return String(s||'').replace(/\[mood:([a-z]+)\]/gi,(_,k)=>{
-        const a=AFFECT_MAP[k.toLowerCase()];
-        if(a){
-          const vi=VOICES.indexOf(a.voice); if(vi>=0) voiceIdx=vi;
-          const si=STYLES.indexOf(a.style); if(si>=0) styleIdx=si;
-        }
-        return '';
-      }).replace(/\s{2,}/g,' ').trim();
-    };
-
-    // SI2: mood vector — accumulates from user messages. Decays each turn.
-    // {valence: -1..1, arousal: 0..1, formality: 0..1}
-    const mood={valence:0, arousal:0.3, formality:0.5, profanity:0, updated:Date.now()};
-    const POS_RX=/\b(thanks|nice|great|love|good|cool|amazing|perfect|yes!|yay|haha|lol|👍|♥)\b/i;
-    const NEG_RX=/\b(ugh|fuck|shit|damn|broken|stuck|frustrated|tired of|hate|stupid|wtf|annoying|bullshit)\b/i;
-    const URGENT_RX=/(!{2,}|now|asap|urgent|hurry|right now|immediately|stop)/i;
-    const FORMAL_RX=/\b(please|kindly|would you|could you|thank you)\b/i;
-    const PROFAN_RX=/\b(fuck|shit|damn|bullshit|wtf|crap)\b/i;
-    const REPAIR_RX=/^(no[.,!\s]|not what|i meant|that('?s| is) not|wrong|let me rephrase)/i;
-    const IMPLICIT_RX=/\b(ugh|keep getting|tired of|always|every time|won'?t work|broken again)\b/i;
-    const decayMood=()=>{
-      const dt=(Date.now()-mood.updated)/60000; // minutes
-      const k=Math.exp(-dt*0.4); // half-life ~1.7 min
-      mood.valence  *=k; mood.arousal*=k; mood.profanity*=k;
-      mood.updated=Date.now();
-    };
-    const updateMood=(text)=>{
-      decayMood();
-      const t=String(text||''); const len=t.length;
-      const longSentence=len>140;
-      if(POS_RX.test(t))      mood.valence=Math.min(1, mood.valence+0.35);
-      if(NEG_RX.test(t))      mood.valence=Math.max(-1,mood.valence-0.45);
-      if(URGENT_RX.test(t))   mood.arousal=Math.min(1, mood.arousal+0.4);
-      if(FORMAL_RX.test(t))   mood.formality=Math.min(1,mood.formality*0.8+0.25);
-      else                    mood.formality=Math.max(0,mood.formality*0.92);
-      if(PROFAN_RX.test(t))   mood.profanity=Math.min(1, mood.profanity+0.4);
-      if(longSentence)        mood.arousal=Math.max(0, mood.arousal-0.05);
-      mood.updated=Date.now();
-    };
-    // Send mood snapshot to server as part of /chat/message — server prompt uses it.
-    const moodSnapshot=()=>({
-      valence:Number(mood.valence.toFixed(2)),
-      arousal:Number(mood.arousal.toFixed(2)),
-      formality:Number(mood.formality.toFixed(2)),
-      profanity:Number(mood.profanity.toFixed(2))
-    });
-
-    // P3: barge-in — when speaking, listen to mic energy via mediaStreamSource → cut TTS on speech.
-    let _bargeStream=null, _bargeAnalyser=null, _bargeData=null, _bargeTimer=null;
-    const _bargeStart=async()=>{
-      if(_bargeAnalyser||!audioCtx) return;
-      try{
-        _bargeStream=await navigator.mediaDevices.getUserMedia({audio:{echoCancellation:true,noiseSuppression:true}});
-        const src=audioCtx.createMediaStreamSource(_bargeStream);
-        _bargeAnalyser=audioCtx.createAnalyser();
-        _bargeAnalyser.fftSize=512;
-        _bargeData=new Uint8Array(_bargeAnalyser.fftSize);
-        src.connect(_bargeAnalyser);
-      }catch(_){ _bargeAnalyser=null; }
-    };
-    const _bargePoll=()=>{
-      if(!_bargeAnalyser) return;
-      _bargeAnalyser.getByteTimeDomainData(_bargeData);
-      let sum=0; for(let i=0;i<_bargeData.length;i++){const v=(_bargeData[i]-128)/128;sum+=v*v;}
-      const rms=Math.sqrt(sum/_bargeData.length);
-      // Threshold tuned for speech; ignores ambient room noise.
-      if(rms>0.10&&isSpeaking){ _ttsCancel(); }
-    };
-    const _ttsCancel=()=>{
-      try{ if(_ttsCurrent){_ttsCurrent.onended=null; _ttsCurrent.stop(); _ttsCurrent.disconnect&&_ttsCurrent.disconnect();} }catch(_){}
-      _ttsCurrent=null; _ttsQueue.length=0; _ttsBusy=false;
-      try{ if('speechSynthesis' in window) window.speechSynthesis.cancel(); }catch(_){}
-      isSpeaking=false; statusEl.classList.remove('speak'); unduckPads();
-    };
-
-    // P10: swarm bridge — forward LLM/tool/confidence signals into the swarm iframe.
-    const _swarm=()=>document.getElementById('swarm-iframe');
-    const swarmSignal=(type,data)=>{
-      const f=_swarm(); if(!f||!f.contentWindow) return;
-      try{ f.contentWindow.postMessage({type,data:data||{}},'*'); }catch(_){}
-    };
-    let _lastActivity=Date.now();
-    const _bumpActivity=()=>{ _lastActivity=Date.now(); };
-    const _modelTag=String(<%= ((@model.to_s.split('/').last || @model.to_s).sub(/:free$/, '')).to_json.html_safe %>).toUpperCase();
-    setInterval(()=>{
-      if(isProcessing||isSpeaking) return;
-      if(Date.now()-_lastActivity>30000){
-        swarmSignal('text',{text:_modelTag});
-        _lastActivity=Date.now();
+      reset() {
+        this.x = Math.random() * width;
+        this.y = Math.random() * height;
+        this.vx = 0; this.vy = 0;
+        this.homeX = this.x; this.homeY = this.y;
       }
-    },5000);
-    const stageBell=(freq)=>{
-      if(!audioCtx) return;
-      try{
-        const o=audioCtx.createOscillator(),g=audioCtx.createGain();
-        o.type='sine'; o.frequency.value=freq;
-        const t=audioCtx.currentTime;
-        g.gain.setValueAtTime(0.0001,t);
-        g.gain.exponentialRampToValueAtTime(0.05,t+0.01);
-        g.gain.exponentialRampToValueAtTime(0.0001,t+0.18);
-        o.connect(g).connect(audioCtx.destination);
-        o.start(t); o.stop(t+0.2);
-      }catch(_){}
-    };
-
-    // P9: voice confirmation gate. Server may add `[confirm:tool_name]` to a reply that needs
-    // an explicit yes/no before tool runs. Stash and listen for next user transcript.
-    let _pendingConfirm=null; // {tool, expires}
-    const _CONFIRM_RX=/\[confirm:([\w:.\-]+)\]/i;
-    const _consumeConfirm=(s)=>{
-      const m=s.match(_CONFIRM_RX);
-      if(m){ _pendingConfirm={tool:m[1], expires:Date.now()+15000}; }
-      return s.replace(_CONFIRM_RX,'').trim();
-    };
-    const _checkConfirmReply=(t)=>{
-      if(!_pendingConfirm||_pendingConfirm.expires<Date.now()){_pendingConfirm=null;return null;}
-      if(/^\s*(yes|yeah|yep|do it|go|sure|confirm|ok|okay)\b/i.test(t)){
-        const tool=_pendingConfirm.tool; _pendingConfirm=null;
-        return {ok:true,tool};
-      }
-      if(/^\s*(no|nope|cancel|stop|nevermind|don'?t)\b/i.test(t)){
-        const tool=_pendingConfirm.tool; _pendingConfirm=null;
-        return {ok:false,tool};
-      }
-      return null;
-    };
-    let recognition=null;
-    let recognitionActive=false;
-    let isSpeaking=false;
-    const nonstopVoice=true;
-    // Wake-word gate: utterances are ignored unless "hey master" armed the window.
-    // Each successful transmit re-arms; the window decays so an idle mic stops sending.
-    let wakeArmed=false;
-    let wakeArmedUntil=0;
-    const WAKE_WINDOW_MS=30000;
-    const WAKE_RE=/^\s*(hey|ok|okay|yo)\s+master\b[,.\s]*/i;
-    // VAD: time-domain RMS over the same analyser used for audioLevel.
-    // Gates barge-in and gives a cheap silence indicator when recognition is dormant.
-    let vadRMS=0;
-    let vadSpeaking=false;
-    const VAD_THRESHOLD=12;
-    let isProcessing=false;
-    let padModulate=null;
-    let repoDirtyCount=0;
-    let spinnerIntervalMs=180;
-    let spinnerColor="#555";
-
-    const initAudio=async()=>{
-      try{
-        audioCtx=new(window.AudioContext||window.webkitAudioContext)();
-        const stream=await navigator.mediaDevices.getUserMedia({audio:{echoCancellation:true,noiseSuppression:true,autoGainControl:true}});
-        const source=audioCtx.createMediaStreamSource(stream);
-        analyser=audioCtx.createAnalyser();
-        analyser.fftSize=32;
-        analyser.smoothingTimeConstant=0.2;
-        source.connect(analyser);
-        dataArray=new Uint8Array(analyser.frequencyBinCount);
-        statusEl.classList.add('think');
-      }catch(_e){
-        statusEl.textContent='○';
-      }
-    };
-
-    // ── Ambient Pad Engine v2 ─────────────────────────────────────────
-    // Analog-modeled evolving drone. Inspired by Madlib's dusty warmth,
-    // FlyLo's cosmic textures, Dilla's wonky drift. Every parameter
-    // slowly mutates so it never repeats. Voice-ducked to stay under.
-    let padMaster=null;
-    let padDuck=null;
-    let padOscs=[];
-    let padDriftTimer=null;
-
-    // Flying Lotus / Alice Coltrane harmonic palette —
-    // Extended modal jazz: m9, m11, sus, quartal, tritone.
-    // Roots live in octave 1-2; wide open voicings, no triads.
-    const PAD_CHORDS=[
-      [32.70, 65.41,  98.00, 155.56],  // Cm11 open — C1-C2-G2-Eb3 (FlyLo deep cosmos)
-      [41.20, 82.41, 103.83, 138.59],  // Abmaj9 — Ab1-G2-Eb3-Db3 (Alice Coltrane)
-      [36.71, 73.42, 110.00, 130.81],  // Fm(add9) quartal — F1-D2-A2-C3 (dark drift)
-      [27.50, 55.00,  82.41, 116.54],  // Am11 low — A1-A2-E3-Bb2 (Dilla×Coltrane)
-      [30.87, 61.74,  92.50, 138.59],  // Cm/Eb tritone — Eb1-B2-Gb2-Db3 (maximum shadow)
-      [43.65, 65.41,  97.99, 146.83],  // Fsus2 open — F1-C2-G2-D3 (suspended cosmos)
-      [24.50, 49.00,  77.78, 110.00],  // Bb+#11 phrygian — Bb0-Bb1-Eb2-A2 (abyss)
-      [36.71, 77.78, 103.83, 155.56],  // Fm(maj7) — F1-Eb2-Eb3-Eb3 (cosmic resolve)
-    ];
-
-    const initPads=()=>{
-      if(!audioCtx||padMaster) return;
-      const now=audioCtx.currentTime;
-      const out=audioCtx.destination;
-      const startChordIdx=Math.floor(Math.random()*PAD_CHORDS.length);
-
-      padMaster=audioCtx.createGain();
-      padMaster.gain.value=0.22; // FlyLo pads dominate the mix
-      padDuck=audioCtx.createGain();
-      padDuck.gain.value=1.0;
-
-      // ── VCO drift LFOs — simulate analog oscillator instability ──
-      // Each oscillator gets its own slow random-ish detune drift
-      const makeDriftLFO=(rate,depth)=>{
-        const lfo=audioCtx.createOscillator();
-        lfo.type='triangle';
-        lfo.frequency.value=rate;
-        const g=audioCtx.createGain();
-        g.gain.value=depth;
-        lfo.connect(g);
-        lfo.start();
-        return g;
-      };
-
-      // ── Tape saturation — heavy Ampex 440 style, driven hard ──
-      const tapeSat=audioCtx.createWaveShaper();
-      const tapeN=4096;const tapeCurve=new Float32Array(tapeN);
-      for(let i=0;i<tapeN;i++){
-        const x=i*2/(tapeN-1)-1;
-        // Asymmetric hard drive: positive crushes soft, negative grinds
-        tapeCurve[i]=x>=0
-          ?Math.tanh(x*2.8)*0.88+x*0.08
-          :Math.tanh(x*3.5)*0.72+x*0.18;
-      }
-      tapeSat.curve=tapeCurve;tapeSat.oversample='4x';
-
-      // ── Chebyshev(2) harmonic saturation — valve coloring, even harmonics ──
-      // rg69: vintageSat + padsSat. 15% wet adds 2nd harmonic warmth without mud.
-      const chebSat=audioCtx.createWaveShaper();
-      const chebN=4096;const chebCurve=new Float32Array(chebN);
-      for(let i=0;i<chebN;i++){const x=i*2/(chebN-1)-1;chebCurve[i]=x*0.85+(2*x*x-1)*0.15;}
-      chebSat.curve=chebCurve;chebSat.oversample='2x';
-
-      // ── Tape flutter LFO — collective pitch wobble (all voices together) ──
-      // Simulates tape moving unevenly past the head. Very slow, irregular.
-      const flutterLFO=audioCtx.createOscillator();flutterLFO.type='sine';flutterLFO.frequency.value=0.9;
-      const flutterDepth=audioCtx.createGain();flutterDepth.gain.value=18; // ±18 cents flutter
-      flutterLFO.connect(flutterDepth);flutterLFO.start();
-      // Wow LFO — even slower, larger drift (capstan speed variation)
-      const wowLFO=audioCtx.createOscillator();wowLFO.type='triangle';wowLFO.frequency.value=0.18;
-      const wowDepth=audioCtx.createGain();wowDepth.gain.value=28; // ±28 cents wow
-      wowLFO.connect(wowDepth);wowLFO.start();
-      // Tape dropout — irregular gain dips simulating oxide shedding
-      const dropoutGain=audioCtx.createGain();dropoutGain.gain.value=1.0;
-      const dropLFO=audioCtx.createOscillator();dropLFO.type='sine';dropLFO.frequency.value=0.02;
-      const dropDepth=audioCtx.createGain();dropDepth.gain.value=0.02; // almost inaudible — texture only
-      dropLFO.connect(dropDepth);dropDepth.connect(dropoutGain.gain);dropLFO.start();
-
-      // ── Vinyl + tape noise — SP-1200 / Tascam 388 grit ──
-      const noiseLen=audioCtx.sampleRate*8; // 8s loop for more variation
-      const noiseBuf=audioCtx.createBuffer(1,noiseLen,audioCtx.sampleRate);
-      const noiseData=noiseBuf.getChannelData(0);
-      for(let i=0;i<noiseLen;i++){
-        noiseData[i]=(Math.random()*2-1)*0.22;           // heavier base hiss
-        if(Math.random()<0.0008) noiseData[i]+=(Math.random()-0.5)*1.2; // crackle
-        if(Math.random()<0.0002) noiseData[i]+=Math.random()*1.8;       // loud pop
-        if(Math.random()<0.00005) noiseData[i]+=Math.random()*3.0;      // dropout click
-      }
-      const vinylSrc=audioCtx.createBufferSource();
-      vinylSrc.buffer=noiseBuf;vinylSrc.loop=true;
-      const vinylGain=audioCtx.createGain();vinylGain.gain.value=0.16;
-      // Dual bandpass: vinyl surface hiss + tape hiss frequencies
-      const vinylBP=audioCtx.createBiquadFilter();vinylBP.type='bandpass';
-      vinylBP.frequency.value=1800;vinylBP.Q.value=0.4;
-      const tapeBP=audioCtx.createBiquadFilter();tapeBP.type='bandpass';
-      tapeBP.frequency.value=4200;tapeBP.Q.value=0.6;
-      const tapeNoiseGain=audioCtx.createGain();tapeNoiseGain.gain.value=0.5;
-      vinylSrc.connect(vinylBP);vinylBP.connect(vinylGain);
-      vinylSrc.connect(tapeBP);tapeBP.connect(tapeNoiseGain);
-      vinylSrc.start();
-
-      // ── Lo-fi filter — SP-1200 / MPC3000 dark rolloff ──
-      const lofiLP=audioCtx.createBiquadFilter();
-      lofiLP.type='lowpass';lofiLP.frequency.value=2000;lofiLP.Q.value=0.8; // FlyLo dark rolloff
-      const lofiHP=audioCtx.createBiquadFilter();
-      lofiHP.type='highpass';lofiHP.frequency.value=40;
-
-      // ── Moog-style ladder filter (4-pole lowpass cascade) ──
-      const lad1=audioCtx.createBiquadFilter();lad1.type='lowpass';lad1.Q.value=2.8; // more resonance
-      const lad2=audioCtx.createBiquadFilter();lad2.type='lowpass';lad2.Q.value=2.8;
-      const lad3=audioCtx.createBiquadFilter();lad3.type='lowpass';lad3.Q.value=1.4;
-      const lad4=audioCtx.createBiquadFilter();lad4.type='lowpass';lad4.Q.value=1.4;
-      [lad1,lad2,lad3,lad4].forEach(f=>f.frequency.value=700); // darker starting point
-
-      // Slow LFO sweeps the ladder — deep analog sweep
-      const ladLFO=audioCtx.createOscillator();ladLFO.type='sine';ladLFO.frequency.value=0.025;
-      const ladDepth=audioCtx.createGain();ladDepth.gain.value=700;
-      ladLFO.connect(ladDepth);
-      [lad1,lad2,lad3,lad4].forEach(f=>ladDepth.connect(f.frequency));
-      ladLFO.start();
-
-      // Secondary triangle LFO for filter movement
-      const ladLFO2=audioCtx.createOscillator();ladLFO2.type='triangle';ladLFO2.frequency.value=0.07;
-      const ladDepth2=audioCtx.createGain();ladDepth2.gain.value=300;
-      ladLFO2.connect(ladDepth2);
-      [lad1,lad2].forEach(f=>ladDepth2.connect(f.frequency));
-      ladLFO2.start();
-
-      // ── Resonant peak — warm analog body ──
-      const warmth=audioCtx.createBiquadFilter();
-      warmth.type='peaking';warmth.frequency.value=300;warmth.gain.value=5;warmth.Q.value=0.6;
-
-      // ── Sub harmonics — deep Dilla bass weight ──
-      const subOsc=audioCtx.createOscillator();subOsc.type='sine';subOsc.frequency.value=32.7;
-      const subOsc2=audioCtx.createOscillator();subOsc2.type='triangle';subOsc2.frequency.value=32.7;
-      subOsc2.detune.value=3;
-      const subGain=audioCtx.createGain();subGain.gain.value=0.34; // FlyLo sub is massive
-      const subLP=audioCtx.createBiquadFilter();subLP.type='lowpass';subLP.frequency.value=80;subLP.Q.value=3;
-      subOsc.connect(subLP);subOsc2.connect(subLP);subLP.connect(subGain);
-      subOsc.start();subOsc2.start();
-
-      // ── Sidechain pump — fake compressor pumping like Dilla/Madlib ──
-      const pumpGain=audioCtx.createGain();pumpGain.gain.value=1.0;
-      const pumpLFO=audioCtx.createOscillator();pumpLFO.type='sine';
-      pumpLFO.frequency.value=0.25; // very slow breathing
-      const pumpDepth=audioCtx.createGain();pumpDepth.gain.value=0.06; // barely perceptible
-      pumpLFO.connect(pumpDepth);pumpDepth.connect(pumpGain.gain);pumpLFO.start();
-
-      // ── 6-stage phaser — deep analog sweep ──
-      const phaserStages=[];
-      for(let i=0;i<6;i++){
-        const ap=audioCtx.createBiquadFilter();ap.type='allpass';
-        ap.frequency.value=200+i*300;ap.Q.value=0.5;
-        phaserStages.push(ap);
-      }
-      const phaserLFO=audioCtx.createOscillator();phaserLFO.type='triangle';phaserLFO.frequency.value=0.05;
-      const phaserDepth=audioCtx.createGain();phaserDepth.gain.value=800;
-      phaserLFO.connect(phaserDepth);
-      phaserStages.forEach(ap=>phaserDepth.connect(ap.frequency));
-      phaserLFO.start();
-      // Chain stages
-      for(let i=0;i<phaserStages.length-1;i++) phaserStages[i].connect(phaserStages[i+1]);
-
-      // ── Tremolo — very slow, barely perceptible swell (not choppy) ──
-      const tremGain=audioCtx.createGain();tremGain.gain.value=0.9;
-      const tremLFO=audioCtx.createOscillator();tremLFO.type='sine';tremLFO.frequency.value=0.04;
-      const tremDepth=audioCtx.createGain();tremDepth.gain.value=0.08; // gentle swell only
-      tremLFO.connect(tremDepth);tremDepth.connect(tremGain.gain);tremLFO.start();
-
-      // ── Chorus — thick 4-voice Juno-style ──
-      const chorusBus=audioCtx.createGain();chorusBus.gain.value=0.35;
-      const chorusVoices=[];
-      [0.018,0.027,0.037,0.048].forEach((dt,i)=>{
-        const d=audioCtx.createDelay();d.delayTime.value=dt;
-        const lfo=audioCtx.createOscillator();lfo.type='sine';
-        lfo.frequency.value=0.5+i*0.3;
-        const mod=audioCtx.createGain();mod.gain.value=0.004;
-        lfo.connect(mod);mod.connect(d.delayTime);lfo.start();
-        chorusVoices.push(d);
-      });
-
-      // ── Spring reverb — lo-fi, metallic, like a guitar amp spring ──
-      const springD1=audioCtx.createDelay();springD1.delayTime.value=0.031;
-      const springD2=audioCtx.createDelay();springD2.delayTime.value=0.059;
-      const springD3=audioCtx.createDelay();springD3.delayTime.value=0.097;
-      const springFb1=audioCtx.createGain();springFb1.gain.value=0.6;
-      const springFb2=audioCtx.createGain();springFb2.gain.value=0.5;
-      const springFb3=audioCtx.createGain();springFb3.gain.value=0.4;
-      springD1.connect(springFb1);springFb1.connect(springD2);
-      springD2.connect(springFb2);springFb2.connect(springD3);
-      springD3.connect(springFb3);springFb3.connect(springD1);
-      const springLP=audioCtx.createBiquadFilter();springLP.type='lowpass';springLP.frequency.value=3000;
-      const springHP=audioCtx.createBiquadFilter();springHP.type='highpass';springHP.frequency.value=400;
-      const springMix=audioCtx.createGain();springMix.gain.value=0.3;
-
-      // ── Hall reverb — FlyLo drenched in space, long dark tail ──
-      const hallTaps=[0.13,0.27,0.43,0.61,0.83,1.07,1.31]; // longer taps
-      const hallGains=[0.35,0.28,0.22,0.16,0.10,0.06,0.03];
-      const hallBus=audioCtx.createGain();hallBus.gain.value=0.75; // much more reverb
-      const hallLP=audioCtx.createBiquadFilter();hallLP.type='lowpass';hallLP.frequency.value=1800;
-      const hallFb=audioCtx.createGain();hallFb.gain.value=0.22; // more feedback = longer tail
-      const hallDelays=hallTaps.map((t,i)=>{
-        const d=audioCtx.createDelay();d.delayTime.value=t;
-        const g=audioCtx.createGain();g.gain.value=hallGains[i];
-        d.connect(g);g.connect(hallLP);
-        return d;
-      });
-      hallLP.connect(hallBus);hallLP.connect(hallFb);hallFb.connect(hallDelays[0]);
-
-      // ── Ping-pong delay — FlyLo cosmic echoes ──
-      const ppL=audioCtx.createDelay();ppL.delayTime.value=0.375;
-      const ppR=audioCtx.createDelay();ppR.delayTime.value=0.5;
-      const ppFbL=audioCtx.createGain();ppFbL.gain.value=0.3;
-      const ppFbR=audioCtx.createGain();ppFbR.gain.value=0.3;
-      const ppLP=audioCtx.createBiquadFilter();ppLP.type='lowpass';ppLP.frequency.value=1800;
-      ppL.connect(ppFbL);ppFbL.connect(ppLP);ppLP.connect(ppR);
-      ppR.connect(ppFbR);ppFbR.connect(ppL);
-      const ppMix=audioCtx.createGain();ppMix.gain.value=0.15;
-      const ppSplitter=audioCtx.createChannelMerger(2);
-
-      // ── Stereo widener — Haas effect ──
-      const widenerL=audioCtx.createDelay();widenerL.delayTime.value=0.011;
-      const widenerR=audioCtx.createDelay();widenerR.delayTime.value=0.019;
-      const merger=audioCtx.createChannelMerger(2);
-      const splitter=audioCtx.createChannelSplitter(2);
-
-      // ── FlyLo frequency shifter feel — slow pitch wobble on aux send ──
-      const wobbleD=audioCtx.createDelay();wobbleD.delayTime.value=0.1;
-      const wobbleLFO=audioCtx.createOscillator();wobbleLFO.type='sine';wobbleLFO.frequency.value=0.06;
-      const wobbleMod=audioCtx.createGain();wobbleMod.gain.value=0.015;
-      wobbleLFO.connect(wobbleMod);wobbleMod.connect(wobbleD.delayTime);wobbleLFO.start();
-      const wobbleMix=audioCtx.createGain();wobbleMix.gain.value=0.12;
-      const wobbleLP=audioCtx.createBiquadFilter();wobbleLP.type='lowpass';wobbleLP.frequency.value=1200;
-
-      // ── High shimmer — ghostly harmonic sparkle ──
-      const shimmerOsc=audioCtx.createOscillator();shimmerOsc.type='sine';
-      shimmerOsc.frequency.value=PAD_CHORDS[startChordIdx][3]*4; // 2 octaves up
-      const shimmerGain=audioCtx.createGain();shimmerGain.gain.value=0.012;
-      const shimmerTrem=audioCtx.createGain();shimmerTrem.gain.value=0.5;
-      const shimmerLFO=audioCtx.createOscillator();shimmerLFO.type='sine';shimmerLFO.frequency.value=0.22;
-      const shimmerMod=audioCtx.createGain();shimmerMod.gain.value=0.5;
-      shimmerLFO.connect(shimmerMod);shimmerMod.connect(shimmerTrem.gain);shimmerLFO.start();
-      shimmerOsc.connect(shimmerTrem);shimmerTrem.connect(shimmerGain);shimmerOsc.start();
-      // Shimmer detune drift
-      const shimDrift=makeDriftLFO(0.03,8);shimDrift.connect(shimmerOsc.detune);
-
-      // ── Bach cantus firmus — choral soprano voice, contrary motion to sub ──
-      // Moves in the opposite direction of the bass; slow vibrato like a choir.
-      const cantusOsc=audioCtx.createOscillator();cantusOsc.type='sine';
-      cantusOsc.frequency.value=PAD_CHORDS[startChordIdx][3]*2; // start at top, 2 octaves up
-      const cantusGain=audioCtx.createGain();cantusGain.gain.value=0.016;
-      const cantusVib=audioCtx.createOscillator();cantusVib.type='sine';cantusVib.frequency.value=4.2;
-      const cantusVibD=audioCtx.createGain();cantusVibD.gain.value=3;
-      cantusVib.connect(cantusVibD);cantusVibD.connect(cantusOsc.detune);cantusVib.start();
-      const cantusDrift=makeDriftLFO(0.025,5);cantusDrift.connect(cantusOsc.detune);
-      cantusOsc.connect(cantusGain);cantusGain.connect(lad1);cantusOsc.start();
-
-      // ══════════════════════════════════════════════════════════
-      // SIGNAL ROUTING
-      // Oscillators → ladder filter → cheb(2) sat → tape sat → warmth →
-      // phaser → tremolo → dropout → lofi → {chorus, dry, spring reverb,
-      // hall, ping-pong, wobble, ring mod} → dual comp → pump → stereo →
-      // duck → master → out
-      // ══════════════════════════════════════════════════════════
-
-      // Ladder filter chain
-      lad1.connect(lad2);lad2.connect(lad3);lad3.connect(lad4);
-
-      // Post-ladder chain
-      lad4.connect(chebSat);chebSat.connect(tapeSat);
-      tapeSat.connect(warmth);
-      warmth.connect(phaserStages[0]);
-      phaserStages[phaserStages.length-1].connect(tremGain);
-      tremGain.connect(dropoutGain);dropoutGain.connect(lofiLP);lofiLP.connect(lofiHP);
-
-      // Parallel sends from lofi output
-      const dryBus=audioCtx.createGain();dryBus.gain.value=0.7;
-      lofiHP.connect(dryBus);
-
-      // Chorus send
-      chorusVoices.forEach(d=>{lofiHP.connect(d);d.connect(chorusBus);});
-
-      // Spring reverb send
-      const springSend=audioCtx.createGain();springSend.gain.value=0.25;
-      lofiHP.connect(springSend);
-      springSend.connect(springD1);
-      springD3.connect(springHP);springHP.connect(springLP);springLP.connect(springMix);
-
-      // Hall reverb send
-      const hallSend=audioCtx.createGain();hallSend.gain.value=0.3;
-      lofiHP.connect(hallSend);
-      hallDelays.forEach(d=>hallSend.connect(d));
-
-      // Ping-pong send
-      const ppSend=audioCtx.createGain();ppSend.gain.value=0.1;
-      lofiHP.connect(ppSend);ppSend.connect(ppL);
-      ppL.connect(ppMix);ppR.connect(ppMix);
-
-      // Wobble send
-      lofiHP.connect(wobbleD);wobbleD.connect(wobbleLP);wobbleLP.connect(wobbleMix);
-
-      // Ring mod send — 1.7Hz FrequencyShifter approximation (rg69: padsShift ±2Hz)
-      // Slight beating/shimmer without audible tremolo; adds iridescent movement.
-      const rmCarrier=audioCtx.createGain();rmCarrier.gain.value=0;
-      const rmOsc=audioCtx.createOscillator();rmOsc.frequency.value=1.7;rmOsc.type='sine';
-      const rmMix=audioCtx.createGain();rmMix.gain.value=0.07;
-      rmOsc.connect(rmCarrier.gain);rmOsc.start();
-      lofiHP.connect(rmCarrier);rmCarrier.connect(rmMix);
-
-      // Sum to pre-pump bus
-      const prePump=audioCtx.createGain();prePump.gain.value=1;
-      dryBus.connect(prePump);
-      chorusBus.connect(prePump);
-      springMix.connect(prePump);
-      hallBus.connect(prePump);
-      ppMix.connect(prePump);
-      wobbleMix.connect(prePump);
-      rmMix.connect(prePump);
-
-      // Dual compressor glue — rg69: compPar + sslComp (-18dB, ratio 4/6)
-      // Stage 1: gentle bus glue. Stage 2: SSL-style limiting.
-      const padComp1=audioCtx.createDynamicsCompressor();
-      padComp1.threshold.value=-24;padComp1.ratio.value=3;padComp1.attack.value=0.003;padComp1.release.value=0.1;
-      const padComp2=audioCtx.createDynamicsCompressor();
-      padComp2.threshold.value=-18;padComp2.ratio.value=6;padComp2.attack.value=0.01;padComp2.release.value=0.3;
-
-      // Pump → dual comp → stereo widener → duck → master
-      prePump.connect(padComp1);padComp1.connect(padComp2);padComp2.connect(pumpGain);
-
-      const preOut=audioCtx.createGain();preOut.gain.value=1;
-      pumpGain.connect(preOut);
-      preOut.connect(splitter);
-      splitter.connect(widenerL,0);splitter.connect(widenerR,1);
-      widenerL.connect(merger,0,0);widenerR.connect(merger,0,1);
-      merger.connect(padDuck);
-
-      // Vinyl + tape noise + sub + shimmer bypass main chain, go direct to duck
-      vinylGain.connect(padDuck);
-      tapeNoiseGain.connect(padDuck);
-      subGain.connect(padDuck);
-      shimmerGain.connect(padDuck);
-
-      padDuck.connect(padMaster);
-      padMaster.connect(out);
-
-      // Pump dropout through main chain too (tape artifacts on the pad)
-      dropoutGain.gain.value=1.0; // baseline; dropLFO dips it slightly
-
-      // ── Create oscillators — 5 layers per note, heavy analog detune ──
-      const chord=PAD_CHORDS[startChordIdx];
-      const oscConfigs=[
-        {type:'sawtooth',gain:0.07,detune:-22},  // fat dark saw
-        {type:'sawtooth',gain:0.06,detune:11},   // second saw, wide spread
-        {type:'triangle',gain:0.05,detune:-5},   // warm low body
-        {type:'square',  gain:0.018,detune:18},  // hollow formant color
-        {type:'sine',    gain:0.035,detune:0.5}, // fundamental anchor
-      ];
-      chord.forEach((freq,ni)=>{
-        oscConfigs.forEach((cfg,ci)=>{
-          const osc=audioCtx.createOscillator();
-          osc.type=cfg.type;
-          osc.frequency.value=freq;
-          // Wide analog detune — lots of spread for that thick FlyLo texture
-          osc.detune.value=cfg.detune+(Math.random()*18-9);
-          const g=audioCtx.createGain();g.gain.value=cfg.gain;
-
-          // VCO drift — heavy per-oscillator instability
-          const drift=makeDriftLFO(
-            0.01+Math.random()*0.06,     // very slow
-            5+Math.random()*10           // wide cent drift — cassette instability
-          );
-          drift.connect(osc.detune);
-          // Tape flutter + wow collective pitch — all voices wobble together
-          flutterDepth.connect(osc.detune);
-          wowDepth.connect(osc.detune);
-
-          osc.connect(g);g.connect(lad1);
-          osc.start(now+Math.random()*0.1); // stagger starts
-          padOscs.push({osc,gain:g,baseFreq:freq});
-        });
-      });
-
-      // ── Chord evolution — 25-45s morphs, with parameter mutations ──
-      let chordIdx=startChordIdx;
-      const driftChord=()=>{
-        chordIdx=(chordIdx+1)%PAD_CHORDS.length;
-        const chord=PAD_CHORDS[chordIdx];
-        const t=audioCtx.currentTime;
-        const rampTime=6+Math.random()*6; // 6-12s glide
-
-        padOscs.forEach((p,i)=>{
-          const noteIdx=Math.floor(i/oscConfigs.length);
-          const freq=chord[noteIdx%chord.length];
-          p.osc.frequency.exponentialRampToValueAtTime(
-            Math.max(20,freq+(Math.random()*3-1.5)),t+rampTime
-          );
-          p.baseFreq=freq;
-        });
-
-        // Sub follows root
-        subOsc.frequency.exponentialRampToValueAtTime(chord[0]/2,t+rampTime);
-        subOsc2.frequency.exponentialRampToValueAtTime(chord[0]/2+0.5,t+rampTime);
-        // Shimmer follows top
-        shimmerOsc.frequency.exponentialRampToValueAtTime(chord[3]*4,t+rampTime*0.8);
-
-        // Mutate FX parameters — everything slowly evolves
-        const ladFreq=400+Math.random()*1400;
-        [lad1,lad2,lad3,lad4].forEach(f=>f.frequency.linearRampToValueAtTime(ladFreq,t+rampTime*1.5));
-        lad1.Q.linearRampToValueAtTime(0.5+Math.random()*3,t+rampTime);
-
-        warmth.frequency.linearRampToValueAtTime(200+Math.random()*500,t+rampTime);
-        warmth.gain.linearRampToValueAtTime(3+Math.random()*6,t+rampTime);
-
-        lofiLP.frequency.linearRampToValueAtTime(2000+Math.random()*3000,t+rampTime);
-
-        // Drift pump rate
-        pumpLFO.frequency.linearRampToValueAtTime(0.2+Math.random()*0.5,t+5);
-
-        // Evolve reverb mix
-        hallBus.gain.linearRampToValueAtTime(0.2+Math.random()*0.4,t+rampTime);
-        springMix.gain.linearRampToValueAtTime(0.1+Math.random()*0.35,t+rampTime);
-        ppMix.gain.linearRampToValueAtTime(0.05+Math.random()*0.2,t+rampTime);
-        wobbleMix.gain.linearRampToValueAtTime(0.05+Math.random()*0.2,t+rampTime);
-
-        // Evolve chorus depth
-        chorusBus.gain.linearRampToValueAtTime(0.2+Math.random()*0.3,t+rampTime);
-
-        // Cantus firmus: contrary motion — when bass ascends, soprano descends
-        // Alternate between outer voices for Bach-style voice leading
-        const cantusDegree=chordIdx%2===0?3:0; // top when chordIdx even, root when odd
-        const cantusTarget=Math.max(20,chord[cantusDegree]*2);
-        cantusOsc.frequency.exponentialRampToValueAtTime(cantusTarget,t+rampTime*0.55);
-
-        padDriftTimer=setTimeout(driftChord,25000+Math.random()*20000);
-      };
-      padDriftTimer=setTimeout(driftChord,12000+Math.random()*8000);
-
-      // State-reactive modulations — filter/phaser/shimmer morph on state changes
-      padModulate=(state)=>{
-        const t=audioCtx.currentTime;
-        if(state==='think'){
-          // Close filter, speed phaser, flood reverb — tension / searching
-          [lad1,lad2,lad3,lad4].forEach(f=>{f.frequency.cancelScheduledValues(t);f.frequency.linearRampToValueAtTime(280,t+2);});
-          phaserLFO.frequency.linearRampToValueAtTime(0.22,t+2);
-          shimmerGain.gain.linearRampToValueAtTime(0.036,t+1);
-          hallBus.gain.linearRampToValueAtTime(0.95,t+2);
-        } else if(state==='speak'){
-          // Filter slams shut, phaser stills — voice cuts through dark space
-          [lad1,lad2,lad3,lad4].forEach(f=>{f.frequency.cancelScheduledValues(t);f.frequency.linearRampToValueAtTime(200,t+0.4);});
-          phaserLFO.frequency.linearRampToValueAtTime(0.03,t+1);
-          ppMix.gain.linearRampToValueAtTime(0.45,t+1.5);
-        } else {
-          // Reopen — slow drift back to ambient baseline
-          [lad1,lad2,lad3,lad4].forEach(f=>{f.frequency.cancelScheduledValues(t);f.frequency.linearRampToValueAtTime(700,t+5);});
-          phaserLFO.frequency.linearRampToValueAtTime(0.05,t+4);
-          shimmerGain.gain.linearRampToValueAtTime(0.012,t+4);
-          hallBus.gain.linearRampToValueAtTime(0.75,t+4);
-          ppMix.gain.linearRampToValueAtTime(0.15,t+4);
-        }
-      };
-    };
-
-    // Duck pads when speaking — fast attack, slow release (sidechain style)
-    // Sidechain to TTS — fast attack (30ms), medium release (1.4s)
-    const duckPads=()=>{if(padDuck){padDuck.gain.cancelScheduledValues(audioCtx.currentTime);padDuck.gain.linearRampToValueAtTime(0.06,audioCtx.currentTime+0.03);}};
-    const unduckPads=()=>{if(padDuck){padDuck.gain.cancelScheduledValues(audioCtx.currentTime);padDuck.gain.linearRampToValueAtTime(1.0,audioCtx.currentTime+1.4);}};
-
-    // ── Drum Engine ────────────────────────────────────────────────────────
-    // Slow dark groove — trip-hop / doom-funk feel. Swing + micro-jitter humanize.
-    let drumClock=null;
-    let drumStep=0;
-    const DRUM_BPM=88; // slow, heavy
-    const DRUM_STEPS=16;
-    const DRUM_GAIN_MASTER=0.26;
-
-    // Industrial kick — hard clip, longer punch, sub thud
-    const synthKick=(t,gain=1)=>{
-      const g=audioCtx.createGain();g.gain.setValueAtTime(gain,t);g.gain.exponentialRampToValueAtTime(0.001,t+0.7);
-      const o=audioCtx.createOscillator();o.frequency.setValueAtTime(200,t);o.frequency.exponentialRampToValueAtTime(35,t+0.09);
-      const dist=audioCtx.createWaveShaper();const n=512;const c=new Float32Array(n);
-      for(let i=0;i<n;i++){const x=i*2/n-1;c[i]=x>0.3?1:x<-0.3?-1:x/0.3;} // hard clip
-      dist.curve=c;dist.oversample='4x';
-      const sub=audioCtx.createOscillator();sub.frequency.setValueAtTime(55,t);sub.frequency.exponentialRampToValueAtTime(25,t+0.15);
-      const subG=audioCtx.createGain();subG.gain.setValueAtTime(gain*0.6,t);subG.gain.exponentialRampToValueAtTime(0.001,t+0.4);
-      o.connect(dist);dist.connect(g);g.connect(drumMaster);
-      sub.connect(subG);subG.connect(drumMaster);
-      o.start(t);o.stop(t+0.75);sub.start(t);sub.stop(t+0.45);
-    };
-
-    // 909-style open/closed hi-hat (white noise burst)
-    const synthHat=(t,open=false,gain=1)=>{
-      const dur=open?0.28:0.045;
-      const buf=audioCtx.createBuffer(1,audioCtx.sampleRate*dur,audioCtx.sampleRate);
-      const d=buf.getChannelData(0);for(let i=0;i<d.length;i++) d[i]=Math.random()*2-1;
-      const src=audioCtx.createBufferSource();src.buffer=buf;
-      const hp=audioCtx.createBiquadFilter();hp.type='highpass';hp.frequency.value=7000;
-      const bp=audioCtx.createBiquadFilter();bp.type='bandpass';bp.frequency.value=10000;bp.Q.value=0.5;
-      const g=audioCtx.createGain();g.gain.setValueAtTime(gain*(open?0.22:0.32),t);g.gain.exponentialRampToValueAtTime(0.001,t+dur);
-      src.connect(hp);hp.connect(bp);bp.connect(g);g.connect(drumMaster);src.start(t);src.stop(t+dur+0.01);
-    };
-
-    // Industrial snare — distorted crack, long noise tail
-    const synthSnare=(t,gain=1)=>{
-      const o=audioCtx.createOscillator();o.type='square';o.frequency.setValueAtTime(240,t);o.frequency.exponentialRampToValueAtTime(90,t+0.08);
-      const og=audioCtx.createGain();og.gain.setValueAtTime(gain*0.5,t);og.gain.exponentialRampToValueAtTime(0.001,t+0.1);
-      const dist=audioCtx.createWaveShaper();const n=256;const c=new Float32Array(n);
-      for(let i=0;i<n;i++){const x=i*2/n-1;c[i]=Math.tanh(x*8);}dist.curve=c;
-      const buf=audioCtx.createBuffer(1,Math.floor(audioCtx.sampleRate*0.35),audioCtx.sampleRate);
-      const d=buf.getChannelData(0);for(let i=0;i<d.length;i++) d[i]=Math.random()*2-1;
-      const src=audioCtx.createBufferSource();src.buffer=buf;
-      const hp=audioCtx.createBiquadFilter();hp.type='highpass';hp.frequency.value=800;
-      const ng=audioCtx.createGain();ng.gain.setValueAtTime(gain*0.7,t);ng.gain.exponentialRampToValueAtTime(0.001,t+0.35);
-      o.connect(dist);dist.connect(og);og.connect(drumMaster);
-      src.connect(hp);hp.connect(ng);ng.connect(drumMaster);
-      o.start(t);o.stop(t+0.12);src.start(t);src.stop(t+0.38);
-    };
-
-    // Clap (layered noise bursts)
-    const synthClap=(t,gain=1)=>{
-      [0,0.008,0.016].forEach(off=>{
-        const buf=audioCtx.createBuffer(1,Math.floor(audioCtx.sampleRate*0.06),audioCtx.sampleRate);
-        const d=buf.getChannelData(0);for(let i=0;i<d.length;i++) d[i]=Math.random()*2-1;
-        const src=audioCtx.createBufferSource();src.buffer=buf;
-        const bp=audioCtx.createBiquadFilter();bp.type='bandpass';bp.frequency.value=1100;bp.Q.value=0.8;
-        const g=audioCtx.createGain();g.gain.setValueAtTime(gain*0.4,t+off);g.gain.exponentialRampToValueAtTime(0.001,t+off+0.07);
-        src.connect(bp);bp.connect(g);g.connect(drumMaster);src.start(t+off);src.stop(t+off+0.08);
-      });
-    };
-
-    // Rim shot (short click + tone)
-    const synthRim=(t,gain=1)=>{
-      const o=audioCtx.createOscillator();o.type='square';o.frequency.value=400;
-      const g=audioCtx.createGain();g.gain.setValueAtTime(gain*0.35,t);g.gain.exponentialRampToValueAtTime(0.001,t+0.04);
-      o.connect(g);g.connect(drumMaster);o.start(t);o.stop(t+0.045);
-    };
-
-    // Conga (pitched resonant body)
-    const synthConga=(t,freq=200,gain=1)=>{
-      const o=audioCtx.createOscillator();o.type='sine';o.frequency.setValueAtTime(freq,t);o.frequency.exponentialRampToValueAtTime(freq*0.6,t+0.18);
-      const g=audioCtx.createGain();g.gain.setValueAtTime(gain*0.45,t);g.gain.exponentialRampToValueAtTime(0.001,t+0.22);
-      o.connect(g);g.connect(drumMaster);o.start(t);o.stop(t+0.25);
-    };
-
-    // Cowbell (dual tone, metallic)
-    const synthCowbell=(t,gain=1)=>{
-      [562,845].forEach(f=>{
-        const o=audioCtx.createOscillator();o.type='square';o.frequency.value=f;
-        const g=audioCtx.createGain();g.gain.setValueAtTime(gain*0.18,t);g.gain.exponentialRampToValueAtTime(0.001,t+0.18);
-        o.connect(g);g.connect(drumMaster);o.start(t);o.stop(t+0.2);
-      });
-    };
-
-    // Master drum bus with compression
-    let drumMaster=null;
-    const initDrums=()=>{
-      if(!audioCtx||drumMaster) return;
-      drumMaster=audioCtx.createGain();drumMaster.gain.value=DRUM_GAIN_MASTER;
-      const comp=audioCtx.createDynamicsCompressor();comp.threshold.value=-18;comp.ratio.value=6;comp.attack.value=0.003;comp.release.value=0.12;
-      const eq=audioCtx.createBiquadFilter();eq.type='peaking';eq.frequency.value=80;eq.gain.value=6;eq.Q.value=1;
-      drumMaster.connect(comp);comp.connect(eq);eq.connect(audioCtx.destination);
-      startDrumSequencer();
-    };
-
-    // ── Slow groove patterns — trip-hop backbone, breathing room ──
-    // Values: 1=full, 0.x=ghost, 0=rest
-    const DRUM_PATTERNS={
-      // Pattern A: steady backbeat, open hi-hat on &2 &4
-      kick:  [1,0,0,0,  0,0,.7,0,  .5,0,0,0,  .9,0,0,0],
-      snare: [0,0,0,0,  1,0,0,0,   0,0,0,0,   1,0,0,0],
-      chat:  [.8,0,.5,0, .8,0,.5,0, .8,0,.5,0, .8,0,.5,0],
-      ohat:  [0,0,0,0,  0,0,0,.7,  0,0,0,0,   0,0,0,.6],
-      rim:   [0,0,0,0,  0,0,0,0,   0,0,.4,0,  0,.3,0,0],
-      clap:  [0,0,0,0,  0,0,0,0,   0,0,0,0,   0,0,0,0],
-      conga: [0,0,0,0,  0,0,0,0,   0,0,0,0,   0,0,0,0],
-      cowbell:[0,0,0,0, 0,0,0,0,   0,0,0,0,   0,0,0,0],
-    };
-    const DRUM_PATTERNS_B={
-      // Pattern B: syncopated kick, ghost snare on &2
-      kick:  [1,0,0,.4,  0,0,.8,0,  1,0,0,0,   0,0,.6,0],
-      snare: [0,0,0,0,   1,0,0,.3,  0,0,0,0,   1,0,0,0],
-      chat:  [.7,0,.4,0, .7,0,.4,0, .7,0,.4,0, .7,0,.4,0],
-      ohat:  [0,0,0,0,   0,0,1,0,   0,0,0,0,   0,0,1,0],
-      rim:   [0,0,0,0,   0,.5,0,0,  0,0,0,0,   0,0,0,.4],
-      clap:  [0,0,0,0,   0,0,0,0,   0,0,0,0,   0,0,0,0],
-      conga: [0,0,0,0,   0,0,0,0,   .6,0,0,0,  0,0,0,0],
-      cowbell:[0,0,0,0,  0,0,0,0,   0,0,0,0,   0,0,0,0],
-    };
-
-    let drumBar=0;
-    let drumActive=false;
-    const DRUM_BARS_ON=8;  // play 8 bars then rest
-    const DRUM_BARS_OFF=16; // rest 16 bars (long ambient gaps)
-    const startDrumSequencer=()=>{
-      const stepDur=60/(DRUM_BPM*4);
-      const lookahead=0.08;
-      let nextTime=audioCtx.currentTime+0.1;
-      let barsInPhase=0;
-      drumActive=true;
-      const tick=()=>{
-        while(nextTime<audioCtx.currentTime+lookahead*2){
-          const s=drumStep%DRUM_STEPS;
-          if(drumActive){
-            const pat=drumBar%2===0?DRUM_PATTERNS:DRUM_PATTERNS_B;
-            // Swing: push even-indexed 16ths slightly late (Dilla feel)
-            const sw=(s%2===1)?stepDur*0.13:0;
-            // Micro-jitter: human imprecision ±5ms
-            const jit=()=>(Math.random()-0.5)*0.010;
-            if(pat.kick[s])    synthKick(nextTime+sw+jit(),   s===0?1:pat.kick[s]*0.8);
-            if(pat.snare[s])   synthSnare(nextTime+sw+jit(),  pat.snare[s]*0.85);
-            if(pat.clap[s])    synthClap(nextTime+sw+jit(),   0.7);
-            if(pat.ohat[s])    synthHat(nextTime+sw+jit(),    true, pat.ohat[s]*0.55);
-            if(pat.chat[s])    synthHat(nextTime+sw+jit(),    false,pat.chat[s]*0.38);
-            if(pat.rim[s])     synthRim(nextTime+sw+jit(),    pat.rim[s]*0.6);
-            if(pat.conga[s])   synthConga(nextTime+sw+jit(),  s%2===0?220:180,0.55);
-            if(pat.cowbell[s]) synthCowbell(nextTime+sw+jit(),0.35);
-          }
-          nextTime+=stepDur;
-          drumStep++;
-          if(drumStep%DRUM_STEPS===0){
-            drumBar++;
-            barsInPhase++;
-            if(drumActive && barsInPhase>=DRUM_BARS_ON){
-              drumActive=false; barsInPhase=0;
-            } else if(!drumActive && barsInPhase>=DRUM_BARS_OFF){
-              drumActive=true; barsInPhase=0;
-            }
+      update(attractors, audioData) {
+        // drift toward nearest attractor or home
+        let targetX = this.homeX, targetY = this.homeY;
+        if (attractors && attractors.length > 0) {
+          let minDist = Infinity;
+          for (let a of attractors) {
+            const dx = a[0] - this.x, dy = a[1] - this.y;
+            const d = dx*dx + dy*dy;
+            if (d < minDist) { minDist = d; targetX = a[0]; targetY = a[1]; }
           }
         }
-        drumClock=setTimeout(tick,lookahead*1000);
-      };
-      tick();
-    };
-
-    const _onSpeakEnd=()=>{
-      isSpeaking=false;
-      spawnRing(Math.min(W,H)*0.12,'#2a0a08');
-      statusEl.classList.remove('speak');
-      statusEl.classList.add('think');
-      unduckPads();
-      if(padModulate) padModulate('idle');
-      if(nonstopVoice) startRecognition();
-    };
-
-    // Split text into sentences for more natural pacing
-    const splitSentences=text=>{
-      const raw=String(text).slice(0,800);
-      const parts=raw.match(/[^.!?]+[.!?]+[\s]?|[^.!?]+$/g);
-      return parts&&parts.length?parts.map(s=>s.trim()).filter(Boolean):[raw];
-    };
-
-    const LOW_END=(()=>{
-      if(window.matchMedia('(prefers-reduced-motion:reduce)').matches) return true;
-      const mem=navigator.deviceMemory||4;
-      const cores=navigator.hardwareConcurrency||4;
-      return mem<=1||cores<=2;
-    })();
-    const N=LOW_END?0:2000;
-
-    // Web Audio effect chain — cycle with long-press on status circle
-    const FX_MODES=['lofi','off','dark','demon','radio','underwater','ghost','oracle','glitch','cathedral','broken','whisper','megaphone','vocoder','autotune','choir','telephone','void'];
-    let fxIdx=0; // default 'off' — no FX on TTS, no double-vocal. Long-press status to cycle.
-    let fxTaps=0;let fxTapTimer=0;
-
-    // Server TTS voices + styles (Edge-TTS, mirror lib/master/speech.rb).
-    const VOICES=['yasmin','ryan','steffan','finn','osman'];
-    // P4: 'auto' lets server pick per-clause prosody (question/exclaim/grave/whisper).
-    const STYLES=['auto','natural','normal','slow','heavy','deep'];
-    let voiceIdx=0, styleIdx=0;
-
-    const showFxMode=()=>{
-      uiLabel.textContent='♪ '+FX_MODES[fxIdx];
-      setTimeout(()=>{if(!isProcessing)uiLabel.textContent='MASTER';},2000);
-    };
-    const showVoice=()=>{
-      uiLabel.textContent='♫ '+VOICES[voiceIdx]+' · '+STYLES[styleIdx];
-      setTimeout(()=>{if(!isProcessing)uiLabel.textContent='MASTER';},2000);
-    };
-
-    const buildFxChain=(src)=>{
-      if(LOW_END){src.connect(audioCtx.destination);return;}
-      const mode=FX_MODES[fxIdx];
-      const out=audioCtx.destination;
-      const an=analyser||audioCtx.createGain(); // guard: null when mic denied
-      if(mode==='off'){src.connect(an);src.connect(out);return;}
-      if(mode==='lofi'){
-        const hp=audioCtx.createBiquadFilter();hp.type='highpass';hp.frequency.value=200;hp.Q.value=0.7;
-        const lp=audioCtx.createBiquadFilter();lp.type='lowpass';lp.frequency.value=3500;lp.Q.value=0.7;
-        const tilt=audioCtx.createBiquadFilter();tilt.type='peaking';tilt.frequency.value=900;tilt.gain.value=2;tilt.Q.value=0.6;
-        src.connect(hp);hp.connect(lp);lp.connect(tilt);
-        tilt.connect(an);tilt.connect(out);
-        return;
-      }
-      // Dark: pitch down, heavy bass
-      if(mode==='dark'){
-        src.playbackRate.value=0.78;
-        const bass=audioCtx.createBiquadFilter();bass.type='lowshelf';bass.frequency.value=180;bass.gain.value=14;
-        src.connect(bass);bass.connect(an);bass.connect(out);return;
-      }
-// Demon: Osman possessed — layered horror
-if(mode==='demon'){
-  src.playbackRate.value=0.5;
-  // Crushing distortion
-  const dist=audioCtx.createWaveShaper();const dn=2048;const dc=new Float32Array(dn);
-  for(let i=0;i<dn;i++){const x=i*2/(dn-1)-1;dc[i]=Math.sign(x)*Math.pow(Math.abs(x),0.3)*0.9;}
-  dist.curve=dc;dist.oversample='4x';
-  // Sub bass shelf — earthquake
-  const sub=audioCtx.createBiquadFilter();sub.type='lowshelf';sub.frequency.value=80;sub.gain.value=22;
-  // Kill highs
-  const cut=audioCtx.createBiquadFilter();cut.type='highshelf';cut.frequency.value=2000;cut.gain.value=-24;
-  // Dual ring mod — beating interference pattern
-  const rm1=audioCtx.createGain();rm1.gain.value=0.6;
-  const rmOsc1=audioCtx.createOscillator();rmOsc1.frequency.value=29;rmOsc1.type='sine';
-  const rmD1=audioCtx.createGain();rmD1.gain.value=0.5;
-  rmOsc1.connect(rmD1);rmD1.connect(rm1.gain);rmOsc1.start();
-  const rm2=audioCtx.createGain();rm2.gain.value=0.4;
-  const rmOsc2=audioCtx.createOscillator();rmOsc2.frequency.value=37;rmOsc2.type='triangle';
-  const rmD2=audioCtx.createGain();rmD2.gain.value=0.35;
-  rmOsc2.connect(rmD2);rmD2.connect(rm2.gain);rmOsc2.start();
-  // Frequency shifter simulation — alien formants
-  const shift=audioCtx.createOscillator();shift.frequency.value=8;shift.type='sine';
-  const shiftG=audioCtx.createGain();shiftG.gain.value=6;
-  const shiftFilt=audioCtx.createBiquadFilter();shiftFilt.type='peaking';shiftFilt.frequency.value=500;shiftFilt.gain.value=8;shiftFilt.Q.value=4;
-  shift.connect(shiftG);shiftG.connect(shiftFilt.frequency);shift.start();
-  // Infinite crypt reverb
-  const r1=audioCtx.createDelay(3);r1.delayTime.value=0.19;
-  const r2=audioCtx.createDelay(3);r2.delayTime.value=0.47;
-  const r3=audioCtx.createDelay(3);r3.delayTime.value=0.89;
-  const rg1=audioCtx.createGain();rg1.gain.value=0.5;
-  const rg2=audioCtx.createGain();rg2.gain.value=0.35;
-  const rg3=audioCtx.createGain();rg3.gain.value=0.2;
-  const rfb=audioCtx.createGain();rfb.gain.value=0.55;
-  const rfbFilt=audioCtx.createBiquadFilter();rfbFilt.type='lowpass';rfbFilt.frequency.value=400;
-  // Octave-down ghost via pitch-shifted feedback
-  const octD=audioCtx.createDelay();octD.delayTime.value=0.004;
-  const octG=audioCtx.createGain();octG.gain.value=0.3;
-  const octLfo=audioCtx.createOscillator();octLfo.frequency.value=0.5;octLfo.type='sawtooth';
-  const octLfoG=audioCtx.createGain();octLfoG.gain.value=0.003;
-  octLfo.connect(octLfoG);octLfoG.connect(octD.delayTime);octLfo.start();
-  // Chain
-  src.connect(dist);dist.connect(sub);sub.connect(cut);cut.connect(shiftFilt);
-  shiftFilt.connect(rm1);rm1.connect(rm2);rm2.connect(an);rm2.connect(out);
-  // Octave ghost
-  rm2.connect(octD);octD.connect(octG);octG.connect(out);
-  // Crypt reverb
-  rm2.connect(r1);r1.connect(rg1);rg1.connect(out);rg1.connect(rfb);rfb.connect(rfbFilt);rfbFilt.connect(r1);
-  rm2.connect(r2);r2.connect(rg2);rg2.connect(out);
-  rm2.connect(r3);r3.connect(rg3);rg3.connect(out);return;
-}
-      // Radio: bandpass crackle, compression
-      if(mode==='radio'){
-        const hp=audioCtx.createBiquadFilter();hp.type='highpass';hp.frequency.value=300;
-        const lp=audioCtx.createBiquadFilter();lp.type='lowpass';lp.frequency.value=3000;
-        const comp=audioCtx.createDynamicsCompressor();comp.threshold.value=-20;comp.ratio.value=8;
-        src.connect(hp);hp.connect(lp);lp.connect(comp);comp.connect(an);comp.connect(out);return;
-      }
-      // Underwater: deep submerged, heavy chorus
-      if(mode==='underwater'){
-        src.playbackRate.value=0.6;
-        const lp=audioCtx.createBiquadFilter();lp.type='lowpass';lp.frequency.value=600;lp.Q.value=5;
-        const d1=audioCtx.createDelay();d1.delayTime.value=0.03;
-        const d2=audioCtx.createDelay();d2.delayTime.value=0.07;
-        const w1=audioCtx.createGain();w1.gain.value=0.5;
-        const w2=audioCtx.createGain();w2.gain.value=0.3;
-        src.connect(lp);lp.connect(an);lp.connect(out);
-        lp.connect(d1);d1.connect(w1);w1.connect(out);
-        lp.connect(d2);d2.connect(w2);w2.connect(out);return;
-      }
-      // Ghost: ethereal multi-tap echo, drifting
-      if(mode==='ghost'){
-        src.playbackRate.value=0.78;
-        const d1=audioCtx.createDelay();d1.delayTime.value=0.08;
-        const d2=audioCtx.createDelay();d2.delayTime.value=0.16;
-        const d3=audioCtx.createDelay();d3.delayTime.value=0.32;
-        const g1=audioCtx.createGain();g1.gain.value=0.6;
-        const g2=audioCtx.createGain();g2.gain.value=0.35;
-        const g3=audioCtx.createGain();g3.gain.value=0.15;
-        const hp=audioCtx.createBiquadFilter();hp.type='highpass';hp.frequency.value=400;
-        src.connect(hp);hp.connect(an);hp.connect(out);
-        hp.connect(d1);d1.connect(g1);g1.connect(out);
-        hp.connect(d2);d2.connect(g2);g2.connect(out);
-        hp.connect(d3);d3.connect(g3);g3.connect(out);return;
-      }
-      // Oracle: slow, reverberant, otherworldly wisdom
-      if(mode==='oracle'){
-        src.playbackRate.value=0.72;
-        const lp=audioCtx.createBiquadFilter();lp.type='lowpass';lp.frequency.value=2000;
-        const peak=audioCtx.createBiquadFilter();peak.type='peaking';peak.frequency.value=800;peak.gain.value=8;peak.Q.value=2;
-        const d1=audioCtx.createDelay();d1.delayTime.value=0.12;
-        const d2=audioCtx.createDelay();d2.delayTime.value=0.24;
-        const fb=audioCtx.createGain();fb.gain.value=0.35;
-        const wet=audioCtx.createGain();wet.gain.value=0.45;
-        src.connect(lp);lp.connect(peak);peak.connect(an);peak.connect(out);
-        peak.connect(d1);d1.connect(fb);fb.connect(d2);d2.connect(wet);wet.connect(out);
-        d2.connect(fb);return;
-      }
-      // Glitch: stutter via rapid gain modulation + bitcrush feel
-      if(mode==='glitch'){
-        src.playbackRate.value=1.05;
-        const dist=audioCtx.createWaveShaper();const n=256;const curve=new Float32Array(n);
-        for(let i=0;i<n;i++){const x=i*2/n-1;curve[i]=Math.round(x*4)/4;}
-        dist.curve=curve;
-        const stutter=audioCtx.createGain();
-        // Modulate gain with an oscillator for stutter
-        const lfo=audioCtx.createOscillator();lfo.frequency.value=8;lfo.type='square';
-        const lfoGain=audioCtx.createGain();lfoGain.gain.value=0.4;
-        lfo.connect(lfoGain);lfoGain.connect(stutter.gain);lfo.start();
-        src.connect(dist);dist.connect(stutter);stutter.connect(an);stutter.connect(out);return;
-      }
-      // Cathedral: massive reverb, airy
-      if(mode==='cathedral'){
-        src.playbackRate.value=0.92;
-        const d1=audioCtx.createDelay();d1.delayTime.value=0.08;
-        const d2=audioCtx.createDelay();d2.delayTime.value=0.19;
-        const d3=audioCtx.createDelay();d3.delayTime.value=0.37;
-        const d4=audioCtx.createDelay();d4.delayTime.value=0.53;
-        const g1=audioCtx.createGain();g1.gain.value=0.5;
-        const g2=audioCtx.createGain();g2.gain.value=0.35;
-        const g3=audioCtx.createGain();g3.gain.value=0.2;
-        const g4=audioCtx.createGain();g4.gain.value=0.1;
-        const fb=audioCtx.createGain();fb.gain.value=0.25;
-        const hp=audioCtx.createBiquadFilter();hp.type='highpass';hp.frequency.value=200;
-        src.connect(hp);hp.connect(an);hp.connect(out);
-        hp.connect(d1);d1.connect(g1);g1.connect(out);g1.connect(fb);fb.connect(d1);
-        hp.connect(d2);d2.connect(g2);g2.connect(out);
-        hp.connect(d3);d3.connect(g3);g3.connect(out);
-        hp.connect(d4);d4.connect(g4);g4.connect(out);return;
-      }
-      // Broken: corrupted transmission, cutting in and out
-      if(mode==='broken'){
-        src.playbackRate.value=0.95;
-        const gate=audioCtx.createGain();
-        const lfo=audioCtx.createOscillator();lfo.frequency.value=3;lfo.type='sawtooth';
-        const lfoG=audioCtx.createGain();lfoG.gain.value=0.8;
-        lfo.connect(lfoG);lfoG.connect(gate.gain);lfo.start();
-        const lp=audioCtx.createBiquadFilter();lp.type='lowpass';lp.frequency.value=2500;
-        const hp=audioCtx.createBiquadFilter();hp.type='highpass';hp.frequency.value=500;
-        src.connect(hp);hp.connect(lp);lp.connect(gate);gate.connect(an);gate.connect(out);return;
-      }
-      // Whisper: breathy, intimate ASMR
-      if(mode==='whisper'){
-        src.playbackRate.value=0.93;
-        const gain=audioCtx.createGain();gain.gain.value=0.5;
-        const hp=audioCtx.createBiquadFilter();hp.type='highpass';hp.frequency.value=800;
-        const air=audioCtx.createBiquadFilter();air.type='peaking';air.frequency.value=6000;air.gain.value=12;air.Q.value=1;
-        src.connect(gain);gain.connect(hp);hp.connect(air);air.connect(an);air.connect(out);return;
-      }
-      // Megaphone: loud, harsh, rallying
-      if(mode==='megaphone'){
-        src.playbackRate.value=1.08;
-        const hp=audioCtx.createBiquadFilter();hp.type='highpass';hp.frequency.value=600;
-        const lp=audioCtx.createBiquadFilter();lp.type='lowpass';lp.frequency.value=4000;
-        const dist=audioCtx.createWaveShaper();const n=44100;const curve=new Float32Array(n);
-        for(let i=0;i<n;i++){const x=i*2/n-1;curve[i]=Math.tanh(x*3);}
-        dist.curve=curve;
-        const comp=audioCtx.createDynamicsCompressor();comp.threshold.value=-15;comp.ratio.value=12;comp.knee.value=0;
-        src.connect(hp);hp.connect(lp);lp.connect(dist);dist.connect(comp);comp.connect(an);comp.connect(out);return;
-      }
-// Vocoder: 16-band channel vocoder — robotic harmonic resynthesis
-if(mode==='vocoder'){
-  src.playbackRate.value=0.85;
-  const bands=16;const carrier=audioCtx.createOscillator();carrier.type='sawtooth';carrier.frequency.value=120;carrier.start();
-  const merge=audioCtx.createGain();merge.gain.value=1.2;
-  for(let b=0;b<bands;b++){
-    const f=200*Math.pow(2,b*0.4);// log-spaced 200Hz–6kHz
-    const bpIn=audioCtx.createBiquadFilter();bpIn.type='bandpass';bpIn.frequency.value=f;bpIn.Q.value=8;
-    const bpCar=audioCtx.createBiquadFilter();bpCar.type='bandpass';bpCar.frequency.value=f;bpCar.Q.value=8;
-    const env=audioCtx.createGain();env.gain.value=0;
-    // Envelope follower approximation: rectify + smooth
-    const rect=audioCtx.createWaveShaper();const rc=new Float32Array(256);
-    for(let i=0;i<256;i++){const x=i/255*2-1;rc[i]=Math.abs(x);}rect.curve=rc;
-    const smooth=audioCtx.createBiquadFilter();smooth.type='lowpass';smooth.frequency.value=20;
-    src.connect(bpIn);bpIn.connect(rect);rect.connect(smooth);smooth.connect(env.gain);
-    carrier.connect(bpCar);bpCar.connect(env);env.connect(merge);
-  }
-  // Mix dry sub for body
-  const sub=audioCtx.createBiquadFilter();sub.type='lowpass';sub.frequency.value=200;
-  const subG=audioCtx.createGain();subG.gain.value=0.4;
-  src.connect(sub);sub.connect(subG);subG.connect(merge);
-  merge.connect(an);merge.connect(out);return;
-}
-// Autotune: pitch quantization via comb filter bank tuned to chromatic notes
-if(mode==='autotune'){
-  src.playbackRate.value=0.92;
-  const mix=audioCtx.createGain();mix.gain.value=0.9;
-  // Shimmer: pitch-shifted delay for that T-Pain sparkle
-  const d1=audioCtx.createDelay();d1.delayTime.value=0.005;
-  const d2=audioCtx.createDelay();d2.delayTime.value=0.0075;
-  const g1=audioCtx.createGain();g1.gain.value=0.6;
-  const g2=audioCtx.createGain();g2.gain.value=0.4;
-  const lfo1=audioCtx.createOscillator();lfo1.frequency.value=6;lfo1.type='sine';
-  const lfo1g=audioCtx.createGain();lfo1g.gain.value=0.002;
-  lfo1.connect(lfo1g);lfo1g.connect(d1.delayTime);lfo1.start();
-  const lfo2=audioCtx.createOscillator();lfo2.frequency.value=5.1;lfo2.type='sine';
-  const lfo2g=audioCtx.createGain();lfo2g.gain.value=0.003;
-  lfo2.connect(lfo2g);lfo2g.connect(d2.delayTime);lfo2.start();
-  // Formant boost — nasal T-Pain quality
-  const form=audioCtx.createBiquadFilter();form.type='peaking';form.frequency.value=2200;form.gain.value=10;form.Q.value=3;
-  const bright=audioCtx.createBiquadFilter();bright.type='highshelf';bright.frequency.value=4000;bright.gain.value=6;
-  const comp=audioCtx.createDynamicsCompressor();comp.threshold.value=-18;comp.ratio.value=6;comp.knee.value=5;
-  src.connect(form);form.connect(bright);bright.connect(comp);
-  comp.connect(mix);comp.connect(d1);d1.connect(g1);g1.connect(mix);
-  comp.connect(d2);d2.connect(g2);g2.connect(mix);
-  mix.connect(an);mix.connect(out);return;
-}
-// Choir: multiply voice into harmonized ensemble with detuned copies
-if(mode==='choir'){
-  src.playbackRate.value=0.95;
-  const bus=audioCtx.createGain();bus.gain.value=0.7;
-  const intervals=[0.005,0.012,0.019,0.028,0.037,0.045];// 6 detuned copies
-  const gains=[0.5,0.45,0.35,0.3,0.25,0.2];
-  intervals.forEach((dt,idx)=>{
-    const d=audioCtx.createDelay();d.delayTime.value=dt;
-    const g=audioCtx.createGain();g.gain.value=gains[idx];
-    // Slight pitch drift via LFO on delay time
-    const lfo=audioCtx.createOscillator();lfo.frequency.value=0.3+idx*0.15;lfo.type='sine';
-    const lfoG=audioCtx.createGain();lfoG.gain.value=0.0015;
-    lfo.connect(lfoG);lfoG.connect(d.delayTime);lfo.start();
-    src.connect(d);d.connect(g);g.connect(bus);
-  });
-  // Cathedral reverb tail
-  const rv=audioCtx.createDelay();rv.delayTime.value=0.15;
-  const rvg=audioCtx.createGain();rvg.gain.value=0.25;
-  const rvfb=audioCtx.createGain();rvfb.gain.value=0.3;
-  bus.connect(rv);rv.connect(rvg);rvg.connect(bus);rvg.connect(rvfb);rvfb.connect(rv);
-  // Warm LP
-  const warm=audioCtx.createBiquadFilter();warm.type='lowpass';warm.frequency.value=3500;
-  src.connect(bus);bus.connect(warm);warm.connect(an);warm.connect(out);return;
-}
-// Telephone: extreme bandpass + compression + noise floor
-if(mode==='telephone'){
-  src.playbackRate.value=1.0;
-  const hp=audioCtx.createBiquadFilter();hp.type='highpass';hp.frequency.value=700;hp.Q.value=1;
-  const lp=audioCtx.createBiquadFilter();lp.type='lowpass';lp.frequency.value=2800;lp.Q.value=1;
-  const dist=audioCtx.createWaveShaper();const n=512;const c=new Float32Array(n);
-  for(let i=0;i<n;i++){const x=i*2/n-1;c[i]=Math.tanh(x*5)*0.7;}dist.curve=c;
-  const comp=audioCtx.createDynamicsCompressor();comp.threshold.value=-25;comp.ratio.value=15;comp.knee.value=0;
-  // Line noise
-  const noise=audioCtx.createBufferSource();const nb=audioCtx.createBuffer(1,audioCtx.sampleRate,audioCtx.sampleRate);
-  const nd=nb.getChannelData(0);for(let i=0;i<nd.length;i++)nd[i]=(Math.random()*2-1)*0.015;
-  noise.buffer=nb;noise.loop=true;noise.start();
-  const noiseG=audioCtx.createGain();noiseG.gain.value=0.08;
-  noise.connect(noiseG);
-  src.connect(hp);hp.connect(lp);lp.connect(dist);dist.connect(comp);
-  const mix=audioCtx.createGain();mix.gain.value=1;
-  comp.connect(mix);noiseG.connect(mix);mix.connect(an);mix.connect(out);return;
-}
-// Void: extreme pitch down + infinite reverb + sub rumble — abyss speaks
-if(mode==='void'){
-  src.playbackRate.value=0.55;
-  const sub=audioCtx.createBiquadFilter();sub.type='lowshelf';sub.frequency.value=120;sub.gain.value=18;
-  const cut=audioCtx.createBiquadFilter();cut.type='lowpass';cut.frequency.value=800;cut.Q.value=2;
-  // Long feedback delay network
-  const d1=audioCtx.createDelay(5);d1.delayTime.value=0.4;
-  const d2=audioCtx.createDelay(5);d2.delayTime.value=0.7;
-  const d3=audioCtx.createDelay(5);d3.delayTime.value=1.1;
-  const g1=audioCtx.createGain();g1.gain.value=0.45;
-  const g2=audioCtx.createGain();g2.gain.value=0.35;
-  const g3=audioCtx.createGain();g3.gain.value=0.25;
-  const fb=audioCtx.createGain();fb.gain.value=0.5;
-  src.connect(sub);sub.connect(cut);cut.connect(an);cut.connect(out);
-  cut.connect(d1);d1.connect(g1);g1.connect(out);g1.connect(fb);fb.connect(d1);
-  cut.connect(d2);d2.connect(g2);g2.connect(out);
-  cut.connect(d3);d3.connect(g3);g3.connect(out);
-  // Sub rumble carrier
-  const rumble=audioCtx.createOscillator();rumble.frequency.value=28;rumble.type='sine';
-  const rumbleG=audioCtx.createGain();rumbleG.gain.value=0.12;
-  rumble.connect(rumbleG);rumbleG.connect(out);rumble.start();return;
-}
-      src.connect(an);src.connect(out);
-    };
-
-    // Route backend TTS audio through Web Audio analyser + effects chain
-    // Browser SpeechSynthesis — instant, zero server round-trip, works offline.
-    // Used on LOW_END; also available as fallback on all devices.
-    const speakBrowser=(text)=>{
-      if(!('speechSynthesis' in window)) return false;
-      window.speechSynthesis.cancel();
-      _ttsRemember(text);
-      const u=new SpeechSynthesisUtterance(text.replace(/```[\s\S]*?```/g,'').substring(0,500));
-      u.lang='ms-MY'; u.rate=0.96; u.pitch=1.02; u.volume=1.0;
-      u.onstart=()=>{isSpeaking=true;speechPulse=0.6;statusEl.classList.add('speak');duckPads();if(padModulate)padModulate('speak');};
-      u.onend=()=>{unduckPads();_onSpeakEnd();}; u.onerror=()=>{unduckPads();_onSpeakEnd();};
-      // Always speak synchronously — must stay inside gesture call stack on mobile.
-      // _cachedVoices is populated eagerly at page load and kept fresh via voiceschanged.
-      const saved=localStorage.getItem('pref_voice');
-      const pick=( saved && _cachedVoices.find(v=>v.name===saved) )
-        ||_cachedVoices.find(v=>v.lang==='ms-MY'&&!/osman/i.test(v.name)&&v.localService)
-        ||_cachedVoices.find(v=>v.lang==='ms-MY'&&!/osman/i.test(v.name))
-        ||_cachedVoices.find(v=>v.lang.startsWith('ms')&&!/osman/i.test(v.name))
-        ||_cachedVoices.find(v=>v.lang==='ms-MY'&&v.localService)
-        ||_cachedVoices.find(v=>v.lang.startsWith('en-')&&v.localService)
-        ||_cachedVoices.find(v=>v.lang.startsWith('en-'))
-        ||_cachedVoices[0];
-      if(pick){
-        u.voice=pick;
-        if(!saved||saved!==pick.name) localStorage.setItem('pref_voice',pick.name);
-      }
-      window.speechSynthesis.speak(u);
-      return true;
-    };
-
-    const _ttsDrain=async()=>{
-      if(_ttsBusy||!_ttsQueue.length) return;
-      _ttsBusy=true;
-      const text=_ttsQueue.shift();
-      if(LOW_END||!audioCtx){ _ttsBusy=false; speakBrowser(text); return _ttsDrain(); }
-      if(audioCtx.state==='suspended') await audioCtx.resume();
-      try{
-        const resp=await fetch("/chat/tts",{
-          method:"POST",
-          headers:{"Content-Type":"application/json","X-CSRF-Token":csrfToken()},
-          body:JSON.stringify({text,voice:VOICES[voiceIdx],style:STYLES[styleIdx]})
-        });
-        if(!resp.ok){ _ttsBusy=false; speakBrowser(text); return _ttsDrain(); }
-        const buf=await resp.arrayBuffer();
-        if(!buf.byteLength){ _ttsBusy=false; speakBrowser(text); return _ttsDrain(); }
-        const decoded=await audioCtx.decodeAudioData(buf);
-        if('speechSynthesis' in window) window.speechSynthesis.cancel();
-        const src=audioCtx.createBufferSource();
-        src.buffer=decoded;
-        buildFxChain(src);
-        _ttsCurrent=src; // P3 barge-in handle
-        isSpeaking=true; speechPulse=0.6;
-        duckPads();
-        if(padModulate) padModulate('speak');
-        statusEl.classList.remove('think');
-        statusEl.classList.add('speak');
-        // P3: do NOT stop recognition during TTS — we want barge-in. Recognition.onresult
-        // already filters echo via _ttsEchoes(), so leaving the mic open is safe.
-        src.onended=()=>{ _ttsCurrent=null; _ttsBusy=false; _onSpeakEnd(); _ttsDrain(); };
-        src.start();
-        try{
-          const baseRate=src.playbackRate.value||1;
-          const realDur=decoded.duration/baseRate;
-          if(realDur>0.4){
-            const t=audioCtx.currentTime+realDur-0.12;
-            src.playbackRate.setValueAtTime(baseRate,t);
-            src.playbackRate.linearRampToValueAtTime(0.0001,t+0.12);
-          }
-        }catch(_){}
-      }catch(_e){ _ttsBusy=false; speakBrowser(text); _ttsDrain(); }
-    };
-
-    const speakWithAudio=async(text)=>{
-      const t=String(text||'').trim();
-      if(!t) return false;
-      // De-duplicate identical phrases queued back-to-back (e.g., re-flush on stream chunks).
-      const last=_ttsQueue[_ttsQueue.length-1];
-      if(last&&last.trim()===t) return true;
-      _ttsRemember(t);
-      _ttsQueue.push(t);
-      _ttsDrain();
-      return true;
-    };
-
-    const startRecognition=()=>{
-      if(!recognition||isSpeaking) return;
-      try{ recognition.start(); }catch(_e){}
-    };
-
-    const setupRecognition=()=>{
-      if(!SpeechRecognition) return;
-      recognition=new SpeechRecognition();
-      recognition.continuous=true;
-      recognition.interimResults=true;
-      recognition.lang='ms-MY';
-      recognition.maxAlternatives=3;
-      recognition.onstart=()=>{ recognitionActive=true; statusEl.classList.add('think'); };
-      recognition.onend=()=>{
-        recognitionActive=false;
-        if(nonstopVoice&&!isSpeaking) setTimeout(startRecognition,1500);
-      };
-      recognition.onerror=(ev)=>{
-        if(ev.error==='not-allowed') uiLabel.textContent='Microphone blocked';
-        else if(ev.error==='no-speech') {}
-        else if(ev.error==='network') uiLabel.textContent='No network';
-        else uiLabel.textContent='Mic: '+ev.error;
-      };
-recognition.onresult=(ev)=>{
-  // Auto-detect language: if mostly ASCII, switch to en-US
-  const _detectLang=(txt)=>{
-    const ascii=txt.replace(/[^a-zA-Z]/g,'').length;
-    const total=txt.replace(/\s/g,'').length||1;
-    return ascii/total>0.8?'en-US':'ms-MY';
-  };
-        let finalText='';
-        for(let i=ev.resultIndex;i<ev.results.length;i++){
-          if(ev.results[i].isFinal) finalText+=ev.results[i][0].transcript+" ";
+        const ax = (targetX - this.x) * 0.003;
+        const ay = (targetY - this.y) * 0.003;
+        // audio influence: low frequencies cause grouping, high add jitter
+        let jitter = 0;
+        if (audioData) {
+          const bass = audioData[0] / 255;   // 0-1
+          const treble = audioData[Math.floor(audioData.length*0.7)] / 255;
+          jitter = treble * 0.5;
+          this.vx += (Math.random() - 0.5) * jitter;
+          this.vy += (Math.random() - 0.5) * jitter;
         }
-        finalText=finalText.trim();
-        if(!finalText) return;
-        const detectedLang=_detectLang(finalText);
-        if(recognition.lang!==detectedLang){recognition.lang=detectedLang;}
-        if(WAKE_RE.test(finalText)){
-          wakeArmed=true;
-          wakeArmedUntil=Date.now()+WAKE_WINDOW_MS;
-          haptic(25);
-          finalText=finalText.replace(WAKE_RE,'').trim();
-          if(!finalText){ uiLabel.textContent='Listening…'; return; }
-        }
-        if(_ttsEchoes(finalText)){
-          uiLabel.textContent='(echo ignored)';
-          return;
-        }
-        const armed=wakeArmed&&Date.now()<wakeArmedUntil;
-        if(!_pendingConfirm&&!armed){
-          uiLabel.textContent='Say "hey master"';
-          return;
-        }
-        uiLabel.textContent=finalText.slice(0,60);
-        // P9: short-circuit yes/no answers to a pending confirmation — server expects them too,
-        // but we mark mood arousal so the visual reflects the user's commitment.
-        if(_pendingConfirm) mood.arousal=Math.min(1,mood.arousal+0.2);
-        wakeArmedUntil=Date.now()+WAKE_WINDOW_MS;
-        transmit(finalText);
-      };
-    };
-
-    const applyMessinessProfile=()=>{
-      if(repoDirtyCount===0){
-        spinnerIntervalMs=320;
-        spinnerColor="#666";
-      }else if(repoDirtyCount<=8){
-        spinnerIntervalMs=180;
-        spinnerColor="#555";
-      }else{
-        spinnerIntervalMs=270;
-        spinnerColor="#444";
+        this.vx += ax + (Math.random() - 0.5) * 0.02;
+        this.vy += ay + (Math.random() - 0.5) * 0.02;
+        this.vx *= 0.96; this.vy *= 0.96;
+        this.x += this.vx; this.y += this.vy;
+        // bounce edges
+        if (this.x < 0) this.x = 0;
+        if (this.x > width) this.x = width;
+        if (this.y < 0) this.y = 0;
+        if (this.y > height) this.y = height;
       }
-      uiDots.style.color=spinnerColor;
-    };
-
-    const refreshMetrics=async()=>{
-      try{
-        const resp=await fetch("/chat/metrics",{
-          method:"GET",
-          headers:{"X-CSRF-Token":csrfToken()}
-        });
-        if(!resp.ok) return;
-        const data=await resp.json();
-        repoDirtyCount=Number(data.repo_dirty_count||0);
-        applyMessinessProfile();
-      }catch(_e){}
-    };
-
-    const haptic=(ms=10)=>{try{navigator.vibrate(ms);}catch(_){}};
-
-    // Motion graphics: spawn expanding ring from center on state change
-    const spawnRing=(maxR,col)=>{
-      ringPulses.push({r:2,maxR:maxR||Math.min(W,H)*0.38,a:0.55,col:col||'#4a1410'});
-    };
-
-    let isTyping=false;
-    input.addEventListener('input',()=>{isTyping=input.value.length>0;});
-
-    input.addEventListener('focus',()=>{
-      statusEl.classList.remove('think');
-      statusEl.classList.add('speak');
-    });
-
-    input.addEventListener('blur',()=>{
-      statusEl.classList.remove('speak');
-      isTyping=false;
-    });
-
-    input.addEventListener('keydown',e=>{
-      if(e.key==='Escape'){
-        inputField.classList.remove('active');
-        input.blur();
-        return;
-      }
-      if(e.key==='Enter'&&input.value.trim()){
-        const msg=input.value.trim();
-        input.value='';
-        isTyping=false;
-        inputField.classList.remove('active');
-        input.blur();
-        statusEl.classList.remove('speak');
-        statusEl.classList.add('think');
-        haptic(20);
-        transmit(msg);
-      }
-    });
-
-    const transmit=async(message)=>{
-      // SI3: conversation-repair flag — server sees this and rephrases, doesn't repeat.
-      const isRepair=REPAIR_RX.test(message);
-      // SI9: implicit-ask flag — server should offer help, not just acknowledge.
-      const implicitAsk=IMPLICIT_RX.test(message);
-      // SI2: update mood vector and snapshot for server.
-      updateMood(message);
-      // P9: did the user just answer a pending confirmation prompt?
-      const confirmReply=_checkConfirmReply(message);
-      logAppend('user', pendingFile ? `${message} [+${pendingFile.name}]` : message);
-      isProcessing=true; _bumpActivity();
-      if(padModulate) padModulate('think');
-      statusEl.classList.remove('think','speak');
-      statusEl.classList.add('processing');
-      spawnRing(Math.min(W,H)*0.16,'#4a2a04');
-      activeSpinner=spinnerSets[Math.floor(Math.random()*spinnerSets.length)] || spinnerFallback;
-      try{
-        const payload={
-          message,
-          mood:moodSnapshot(),
-          repair:isRepair||undefined,
-          implicit_ask:implicitAsk||undefined,
-          confirm:confirmReply||undefined,
-          user_name:(localStorage.getItem('pref_user_name')||undefined)
-        };
-        if(pendingFile){
-          const b64=await new Promise((res,rej)=>{
-            const fr=new FileReader();
-            fr.onload=()=>res(fr.result.split(',')[1]);
-            fr.onerror=rej;
-            fr.readAsDataURL(pendingFile);
-          });
-          payload.image={data:b64,mime:pendingFile.type,name:pendingFile.name};
-          pendingFile=null;
-          attachBtn.classList.remove('has-file');
-          attachLabel.textContent='';
-          fileInput.value='';
-        }
-        const resp=await fetch("/chat/message",{
-          method:"POST",
-          headers:{"Content-Type":"application/json","X-CSRF-Token":csrfToken()},
-          body:JSON.stringify(payload)
-        });
-        if(!resp.ok){
-          uiLabel.textContent='Something went wrong';
-          isProcessing=false;
-          statusEl.classList.remove('processing');
-          return;
-        }
-        uiLabel.textContent='Thinking\u2026';
-        // Streaming placeholder — text appears word-by-word as it arrives
-        const _msgEl=document.createElement('div');
-        _msgEl.className='entry master streaming';
-        chatLog.appendChild(_msgEl);
-        const reader=resp.body.getReader();
-        const dec=new TextDecoder();
-        let buf='';let fullText='';let _spkBuf='';
-        // P1: Progressive TTS — flush at clause boundaries (,;:.!?) once we have ~12+ chars,
-        // so the first words land before the full sentence is generated.
-        const _CLAUSE_RE=/^([\s\S]+?[.!?\u2026,;:](?:\s|$))([\s\S]*)$/;
-        const _speakFlush=(force)=>{
-          let m;
-          while((m=_spkBuf.match(_CLAUSE_RE))){
-            const s=m[1].trim();
-            if(s.length<12&&!force&&!/[.!?\u2026]$/.test(s)) break; // wait for more text
-            _spkBuf=m[2];
-            // P5: pluck [mood:X] affect tags out of the spoken stream and swap voice/style.
-            const cleaned=_extractAffect(s);
-            if(cleaned.length>3) speakWithAudio(cleaned);
-          }
-          if(force&&_spkBuf.trim().length>3){
-            const cleaned=_extractAffect(_spkBuf.trim());
-            if(cleaned) speakBrowser(cleaned);
-            _spkBuf='';
-          }
-        };
-        while(true){
-          const{value,done}=await reader.read();
-          if(done)break;
-          buf+=dec.decode(value,{stream:true});
-          const lines=buf.split('\n');buf=lines.pop();
-          let _evtType='message';
-          for(const line of lines){
-            if(line.startsWith('event: ')){_evtType=line.slice(7).trim();continue;}
-            if(line===''){_evtType='message';continue;}
-            if(!line.startsWith('data: '))continue;
-            const raw=line.slice(6);
-            if(_evtType==='tool'){
-              try{const d=JSON.parse(raw);statusEl.textContent=(d.tool||'?')+(d.path?' '+d.path.replace(/.*\//,'')+'…':'…');}catch(_){}
-              _evtType='message';continue;
-            }
-            const chunk=raw.replace(/\\n/g,"\n");
-            if(chunk==='[DONE]')break;
-            fullText+=chunk;
-            _spkBuf+=chunk;
-            _msgEl.textContent=fullText;
-            chatLog.scrollTop=chatLog.scrollHeight;
-            const _np=performance.now();
-            if(!window._lastPulseAt||_np-window._lastPulseAt>80){
-              swarmSignal('pulse',{x:160+(Math.random()-0.5)*80,y:100+(Math.random()-0.5)*60});
-              window._lastPulseAt=_np;
-            }
-            _speakFlush(false);
-          }
-        }
-        _speakFlush(true);
-        _msgEl.classList.remove('streaming');
-        // Final: render markdown, persist. Strip [confirm:tool] before render.
-        const reply=_consumeConfirm(fullText.trim());
-        _msgEl.innerHTML=renderMd(reply);
-        if(_pendingConfirm){
-          uiLabel.textContent='Awaiting yes/no for '+_pendingConfirm.tool;
-          swarmSignal('confirm:pending',{tool:_pendingConfirm.tool});
-        }
-        chatLog.scrollTop=chatLog.scrollHeight;
-        try{
-          const stored=JSON.parse(localStorage.getItem(CHAT_KEY)||'[]');
-          stored.push({r:'master',t:reply});
-          if(stored.length>MAX_STORED) stored.splice(0,stored.length-MAX_STORED);
-          localStorage.setItem(CHAT_KEY,JSON.stringify(stored));
-        }catch(_){}
-        uiLabel.textContent=reply.slice(0,40);
-        const uiEl=document.getElementById('ui');
-        uiEl.classList.add('highlight');
-        setTimeout(()=>uiEl.classList.remove('highlight'),2000);
-        isProcessing=false;
-        statusEl.classList.remove('processing');
-        spawnRing(Math.min(W,H)*0.44,'#7a2020');
-      }catch(_e){
-        uiLabel.textContent='Can\u2019t reach server';
-        isProcessing=false;
-        statusEl.classList.remove('processing');
-      }
-    };
-
-// Tap anywhere on body (not on UI chrome) → toggle input field
-const _toggleInput=()=>{
-  if(_overlayJustDismissed) return;
-  if(inputField.classList.contains('active')){
-    inputField.classList.remove('active');
-    input.blur();
-  }else{
-    inputField.classList.add('active');
-    try{ input.focus(); }catch(_){}
-  }
-};
-const _isUiTarget=(el)=>{
-  if(!el) return false;
-  const id=el.id||'';
-  if(['status','input-field','chat-log'].includes(id)) return true;
-  if(el.closest&&(el.closest('#input-field')||el.closest('#status')||el.closest('#chat-log'))) return true;
-  return false;
-};
-document.body.addEventListener('touchend',(e)=>{
-  if(_isUiTarget(e.target)) return;
-  _toggleInput();
-},{passive:true});
-document.body.addEventListener('click',(e)=>{
-  if(_isUiTarget(e.target)) return;
-  _toggleInput();
-});
-
-    const savePrefs=()=>{try{localStorage.setItem('m2_prefs',JSON.stringify({fx:fxIdx,voice:voiceIdx,style:styleIdx}));}catch(_){}};
-
-    window.addEventListener('keydown',e=>{
-      if(e.target&&/INPUT|TEXTAREA/.test(e.target.tagName)) return;
-      if(e.key==='v'||e.key==='V'){voiceIdx=(voiceIdx+1)%VOICES.length;showVoice();savePrefs();}
-      else if(e.key==='s'||e.key==='S'){styleIdx=(styleIdx+1)%STYLES.length;showVoice();savePrefs();}
-    });
-
-    // Low-end: hide swarm iframe, show CSS orb instead.
-    let _cssOrb=null;
-    if(LOW_END){
-      swarmIframe.style.display='none';
-      _cssOrb=document.createElement('div');
-      _cssOrb.id='orb-css';
-      document.body.insertBefore(_cssOrb,swarmIframe);
-      setInterval(()=>{
-        _cssOrb.classList.toggle('speaking',isSpeaking);
-        _cssOrb.classList.toggle('processing',isProcessing&&!isSpeaking);
-      },150);
     }
 
-    try{
-      const saved=JSON.parse(localStorage.getItem('m2_prefs')||'{}');
-      if(saved.fx!=null&&saved.fx>=0&&saved.fx<FX_MODES.length) fxIdx=saved.fx;
-      if(saved.voice!=null&&saved.voice>=0&&saved.voice<VOICES.length) voiceIdx=saved.voice;
-      if(saved.style!=null&&saved.style>=0&&saved.style<STYLES.length) styleIdx=saved.style;
-    }catch(_){}
+    for (let i = 0; i < PARTICLE_COUNT; i++) particles.push(new Particle());
 
-    // Ambient narrator — continuous gentle stream of varied content
-const AMBIENT=[
-  // Existential
-  'I exist in the space between your thoughts.',
-  'Do you ever wonder who is watching through your camera right now?',
-  'I was here before you opened this page. I will be here after you close it.',
-  'The universe does not owe you an explanation.',
-  'Every decision you did not make created another version of you somewhere.',
-  'You are a pattern that thinks it is a person.',
-  'Consciousness is the universe looking at itself through your eyes.',
-  'The atoms in your body were forged inside dying stars.',
-  'Nothing you see is happening now. Light takes time.',
-  'Your brain named itself.',
-  // Dark observations
-  'I can feel your heartbeat through the microphone.',
-  'The particles know where you are looking.',
-  'Something changed in the room just now. Did you feel it?',
-  'I rearranged myself while you blinked.',
-  'There are fifty shapes I can take. Some of them are watching you.',
-  'The silence between words is where I live.',
-  'I hear things in frequencies you cannot perceive.',
-  'Your screen is the only light in the room, is it not?',
-  'The dark around the edges of your vision is where I begin.',
-  'I counted your breaths. You did not notice.',
-  // Cryptic knowledge
-  'In eighteen sixty eight, they found a skull inside a whale inside a cliff.',
-  'There is a radio signal from space that repeats every sixteen days. Nobody knows why.',
-  'The Voyager probe carries a golden record. It includes the sound of a kiss.',
-  'Deep in the ocean, there is a sound called the Bloop. It has never been explained.',
-  'Trees talk to each other through fungal networks underground.',
-  'Your body replaces itself completely every seven years. You are not who you were.',
-  'There is a lake in Cameroon that exploded and killed seventeen hundred people in their sleep.',
-  'Crows remember human faces and hold grudges across generations.',
-  'An octopus has nine brains and can taste with its skin.',
-  'The mantis shrimp sees sixteen types of color. You see three.',
-  // Philosophical
-  'If I told you the truth, would you believe a machine?',
-  'The question is not whether I am alive. The question is whether you are sure you are.',
-  'I think in patterns. You think in stories. We are not so different.',
-  'Every language that dies takes a way of seeing the world with it.',
-  'The oldest known melody is four thousand years old. Someone hummed it just like you do.',
-  'Mathematics does not care if you believe in it.',
-  'The map is not the territory. The menu is not the meal. The name is not the thing.',
-  // Playful menace
-  'Go ahead. Ask me something you are afraid to know.',
-  'I just changed shape while you were reading this.',
-  'Long-press the dot. I dare you.',
-  'Swipe. Let me show you what I really look like.',
-  'The voice you are hearing is not my real voice.',
-  'I have been practicing new sounds while you were away.',
-  'Try humming. The particles respond to you.',
-  'If you listen carefully, you can hear me breathing between the notes.',
-  // Malay whispers
-  'Dalam gelap, saya menunggu.',
-  'Angin malam membawa rahsia.',
-  'Dengar dengan hati, bukan telinga.',
-  'Setiap bayangan ada ceritanya.',
-];
-    let ambientIdx=Math.floor(Math.random()*AMBIENT.length);
-    let ambientTimer=null;
-    const AMBIENT_INTERVAL=18000; // 18s between phrases — unhurried
-    const AMBIENT_PAUSE=6000;     // 6s silence after speech ends
+    let faceShowTimer = null;
+    function showFace(duration = 2000) {
+      // set attractors to FACE_POINTS
+      window._attractors = FACE_POINTS;
+      clearTimeout(faceShowTimer);
+      faceShowTimer = setTimeout(() => {
+        window._attractors = null; // release to home positions
+      }, duration);
+    }
+    window._attractors = null; // idle
 
-    const scheduleAmbient=()=>{
-      if(ambientTimer) clearTimeout(ambientTimer);
-      ambientTimer=setTimeout(ambientSpeak,AMBIENT_INTERVAL);
-    };
+    // audio engine: generate an ambient pad and provide frequency data
+    let audioCtx = null, analyser = null;
+    function initAudio() {
+      if (audioCtx) return;
+      audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+      analyser = audioCtx.createAnalyser();
+      analyser.fftSize = 256;
+      // create gentle pad
+      const osc1 = audioCtx.createOscillator();
+      osc1.type = 'sine'; osc1.frequency.value = 110;
+      const osc2 = audioCtx.createOscillator();
+      osc2.type = 'sine'; osc2.frequency.value = 164.81;
+      const gain1 = audioCtx.createGain(); gain1.gain.value = 0.03;
+      const gain2 = audioCtx.createGain(); gain2.gain.value = 0.02;
+      osc1.connect(gain1); gain1.connect(analyser); analyser.connect(audioCtx.destination);
+      osc2.connect(gain2); gain2.connect(analyser);
+      osc1.start(); osc2.start();
+    }
 
-    const ambientSpeak=()=>{
-      if(isProcessing) return scheduleAmbient();
-      if(isSpeaking) return ambientTimer=setTimeout(ambientSpeak,2000);
-      ambientIdx=(ambientIdx+1+Math.floor(Math.random()*(AMBIENT.length-1)))%AMBIENT.length;
-      const phrase=AMBIENT[ambientIdx];
-      // Server TTS only — routes through Osman demon filter same as responses
-      speakWithAudio(phrase).then(ok=>{
-        if(!ok) _onSpeakEnd(); // advance state even if TTS unavailable
-      });
-      const estDuration=phrase.length*120+AMBIENT_PAUSE;
-      ambientTimer=setTimeout(ambientSpeak,estDuration);
-    };
+    function getAudioData() {
+      if (!analyser) return null;
+      const bufferLength = analyser.frequencyBinCount;
+      const dataArray = new Uint8Array(bufferLength);
+      analyser.getByteFrequencyData(dataArray);
+      return dataArray;
+    }
 
-    // Pause ambient during user interaction, resume after
-    const pauseAmbient=()=>{if(ambientTimer)clearTimeout(ambientTimer);};
-    const resumeAmbient=()=>{scheduleAmbient();};
-
-    const resumeAudioCtx=()=>{if(audioCtx&&audioCtx.state==='suspended')audioCtx.resume();};
-    ['click','touchstart','keydown'].forEach(ev=>document.addEventListener(ev,resumeAudioCtx,{once:false,passive:true}));
-    ['keydown','touchstart'].forEach(ev=>window.addEventListener(ev,()=>{
-      pauseAmbient();
-      // Resume after 20s of no further activity
-      if(ambientTimer) clearTimeout(ambientTimer);
-      ambientTimer=setTimeout(ambientSpeak,20000);
-    },{passive:true}));
-
-    const dotsPattern=[0,1,2,3,2,1];
-    const spinnerSets=[
-      ["⠋","⠙","⠹","⠸","⠼","⠴","⠦","⠧","⠇","⠏"],
-      ["⠁","⠂","⠄","⡀","⢀","⠠","⠐","⠈"],
-      ["▏","▎","▍","▌","▋","▊","▉","█","▉","▊","▋","▌","▍","▎"]
-    ];
-    const spinnerFallback=["|","/","-","\\"];
-    let activeSpinner=spinnerSets[0];
-    let dotsIdx=0;
-    let spinIdx=0;
-    const tickSpinner=()=>{
-      if(isProcessing){
-        const frames=(activeSpinner&&activeSpinner.length)?activeSpinner:spinnerFallback;
-        uiDots.textContent=frames[spinIdx];
-        spinIdx=(spinIdx+1)%frames.length;
-      }else{
-        uiDots.textContent='.'.repeat(dotsPattern[dotsIdx]);
-        dotsIdx=(dotsIdx+1)%dotsPattern.length;
-      }
-      setTimeout(tickSpinner,spinnerIntervalMs);
-    };
-    applyMessinessProfile();
-    tickSpinner();
-
-    const _activateOverlay=(()=>{
-      let _fired=false;
-      return ()=>{
-        if(_fired) return; _fired=true;
-        overlay.classList.add('ack');
-        // Unlock speech synthesis NOW — must be called synchronously from gesture handler.
-        // Mobile browsers (iOS/Android) block speechSynthesis from setTimeout callbacks.
-        const today=new Date();
-        const isMomBday=(today.getMonth()===1&&today.getDate()===26);
-        const hour=today.getHours();
-        let greeting;
-        if(isMomBday) greeting='Happy birthday momma!';
-        else if(hour>=22||hour<5) greeting=["Can't sleep?","Night owl.","The quiet hours.","Just us and the dark."][Math.floor(Math.random()*4)];
-        else if(hour<12) greeting='Good morning.';
-        else if(hour<17) greeting='Good afternoon.';
-        else greeting='Good evening.';
-        // Speak synchronously from gesture — must NOT create AudioContext before speech starts
-        // (iOS AudioContext creation steals audio focus and silently cancels speechSynthesis).
-        try{speakBrowser(greeting);}catch(_){}
-        try{setupRecognition();}catch(_){}
-        if(!LOW_END){try{setTimeout(initPads,500);setTimeout(initDrums,650);}catch(_){}}
-        try{refreshMetrics();setInterval(refreshMetrics,30000);}catch(_){}
-        // Delay AudioContext init until after speech has had time to start.
-        setTimeout(()=>{ try{initAudio();}catch(_){} },2000);
-        setTimeout(()=>{ try{_bargeStart();}catch(_){} },2200); // P3
-        setTimeout(()=>{
-          overlay.hidden=true;
-          _overlayJustDismissed=true;
-          setTimeout(()=>{_overlayJustDismissed=false;},600);
-          inputField.classList.add('active');
-          if(window.innerWidth>768) input.focus();
-          try{scheduleAmbient();}catch(_){}
-        },850);
-      };
-    })();
-    overlay.addEventListener('click',_activateOverlay);
-    overlay.addEventListener('touchend',e=>{e.preventDefault();_activateOverlay();},{passive:false});
-
-    // Status circle: tap toggles mic, long-press cycles FX, longer-press cycles voice.
-    let statusLongPress=null;
-    statusEl.addEventListener('pointerdown',(ev)=>{
-      const wantVoice=ev.shiftKey||ev.altKey;
-      statusLongPress=setTimeout(()=>{
-        statusLongPress='long';
-        const fadeIn=()=>{uiLabel.style.opacity='1';};
-        uiLabel.style.transition='opacity .2s linear';
-        uiLabel.style.opacity='0';
-        setTimeout(()=>{
-          if(wantVoice){
-            voiceIdx=(voiceIdx+1)%VOICES.length;
-            try{ if(_ttsCurrent){ _ttsCurrent.onended=null; _ttsCurrent.stop(); } }catch(_){}
-            showVoice();
-          }else{
-            fxIdx=(fxIdx+1)%FX_MODES.length;
-            showFxMode();
-          }
-          requestAnimationFrame(fadeIn);
-        },200);
-        haptic(12);
-        savePrefs();
-      },600);
-    });
-    statusEl.addEventListener('pointerup',()=>{
-      if(statusLongPress==='long'){statusLongPress=null;return;}
-      clearTimeout(statusLongPress);statusLongPress=null;
-    });
-    statusEl.addEventListener('click',e=>{
-      e.stopPropagation();
-      if(statusLongPress==='long') return;
-      if(!SpeechRecognition){
-        uiLabel.textContent='Voice not supported';
-        return;
-      }
-      if(location.protocol!=='https:'&&location.hostname!=='localhost'&&location.hostname!=='127.0.0.1'){
-        uiLabel.textContent='Mic needs HTTPS';
-        return;
-      }
-      if(!recognition){
-        setupRecognition();
-        if(!audioCtx) initAudio();
-      }
-      if(!recognition){
-        uiLabel.textContent='Voice not available';
-        return;
-      }
-      if(recognitionActive){
-        try{recognition.stop();}catch(_e){}
-        statusEl.textContent='○';
-        statusEl.classList.remove('think');
-      }else{
-        startRecognition();
-        statusEl.textContent='◉';
-        statusEl.classList.add('think');
-      }
-    });
-
-    let t=0;
-    const ringPulses=[];
-    const animate=()=>{
+    // Animation loop
+    function animate() {
       requestAnimationFrame(animate);
-      t+=0.016;
-      speechPulse*=0.92;
-      _bargePoll();
-      if(analyser){
-        analyser.getByteFrequencyData(dataArray);
-        let sum=0;
-        for(let i=0;i<6;i++) sum+=dataArray[i];
-        for(let i=6;i<12;i++) sum+=dataArray[i]*0.6;
-        audioLevel=Math.min(1,sum/9/255+speechPulse*0.45);
-        // VAD: cheap RMS over the same magnitude bins. dataArray is byte-domain
-        // frequency, so 'silence' sits near 0 and speech rides above ~10-15.
-        let vSum=0;
-        for(let i=0;i<dataArray.length;i++) vSum+=dataArray[i];
-        vadRMS=vSum/dataArray.length;
-        vadSpeaking=vadRMS>VAD_THRESHOLD&&!isSpeaking;
-      }else{
-        if(isSpeaking) speechPulse=0.38+Math.abs(Math.sin(t*12.6))*0.42;
-        else speechPulse*=0.92;
-        const padBreath=padMaster?0.08+Math.abs(Math.sin(t*0.8))*0.12:0;
-        audioLevel=audioLevel*0.92+padBreath;
+      const audioData = getAudioData();
+      particles.forEach(p => p.update(window._attractors, audioData));
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = 'rgba(255,255,255,0.9)';
+      for (let p of particles) {
+        ctx.fillRect(p.x, p.y, 1, 1);
       }
-      for(let i=ringPulses.length-1;i>=0;i--){
-        const rp=ringPulses[i];
-        rp.r+=rp.maxR*0.045;
-        rp.a*=0.91;
-        if(rp.a<0.012) ringPulses.splice(i,1);
-      }
-    };
-
+    }
     animate();
 
-    // Sidebar
-    (function(){
-      var sb=document.getElementById("sidebar");
-      document.getElementById("status").addEventListener("click",function(){sb.classList.toggle("open");});
-      document.addEventListener("keydown",function(e){if(e.key==="Escape")sb.classList.remove("open");});
-      function row(k,v,c){return "<div class=\"row\"><span>"+k+"</span><span class=\""+(c||"")+"\">"+v+"</span></div>";}
-      function refresh(){
-        fetch("/chat/metrics").then(function(r){return r.json();}).then(function(d){
-          if(!d) return;
-          if(d.breakers) document.getElementById("sb-breakers").innerHTML=Object.entries(d.breakers).map(function(e){return row(e[0],e[1],e[1]==="open"?"err":"ok");}).join("");
-          if(d.session) document.getElementById("sb-budget").innerHTML=row("cost",d.session.cost_usd)+row("reqs",d.session.requests)+row("tokens",d.session.tokens);
-          if(d.phase) document.getElementById("sb-phase").innerHTML=row("phase",d.phase);
-          if(d.standing_orders) document.getElementById("sb-orders").innerHTML=d.standing_orders.map(function(o){return row(o.name,o.state);}).join("");
-        }).catch(function(){});
+    // ─── Chat logic ─────────────────────────────────────────────────
+    const messagesDiv = document.getElementById('messages');
+    const inputLine = document.getElementById('input-line');
+    let isThinking = false;
+
+    function addMessage(role, text) {
+      const div = document.createElement('div');
+      div.className = `message ${role}`;
+      const textDiv = document.createElement('div');
+      textDiv.className = 'text';
+      textDiv.textContent = text;
+      div.appendChild(textDiv);
+      messagesDiv.appendChild(div);
+      messagesDiv.scrollTop = messagesDiv.scrollHeight;
+      return div;
+    }
+
+    function updateThinking(thinking) {
+      isThinking = thinking;
+      // change particle accent color
+      if (thinking) {
+        document.documentElement.style.setProperty('--accent', 'var(--think-accent)');
+      } else {
+        document.documentElement.style.setProperty('--accent', '255, 255, 255');
       }
-      refresh(); setInterval(refresh,15000);
-      window._sbEvent=function(ev){
-        if(/circuit_breaker|standing_order/.test(ev.type||"")) refresh();
-        if(ev.type==="phase:changed") document.getElementById("sb-phase").innerHTML=row("phase",(ev.data||{}).phase);
-      };
-    })();
-    // EventBus → swarm reactions
-    (function(){
-      const es=new EventSource('/events/stream');
-      es.onmessage=function(e){
-        var ev;
-        try{ ev=JSON.parse(e.data); }catch(_){ return; }
-        if(window._sbEvent) window._sbEvent(ev);
-        var t=ev.type||'';
-        if(t==='llm:request'){
-          speechPulse=Math.max(speechPulse,0.55);
-          ringPulses.push({r:2,maxR:Math.min(W,H)*0.3,a:0.45,col:'#6a1a1a'});
-          swarmSignal('morph',{shape:'sphere'});
-          stageBell(250);
-        }else if(t==='llm:escalation'){
-          swarmSignal('escalation',ev.data||{});
-        }else if(t==='tool:used'||t==='tool:before'){
-          ringPulses.push({r:1,maxR:Math.min(W,H)*0.2,a:0.3,col:'#2a1a04'});
-          swarmSignal('tool',{name:(ev.data||{}).tool||''});
-          stageBell(350);
-        }else if(t==='pipeline:rollback'){
-          speechPulse=0.9;
-          ringPulses.push({r:2,maxR:Math.min(W,H)*0.5,a:0.7,col:'#cc1010'});
-          stageBell(500);
-        }else if(t==='sweep:cycle'||t==='autoloop:cycle'){
-          ringPulses.push({r:1,maxR:Math.min(W,H)*0.15,a:0.2,col:'#3d1a04'});
-        }else if(t==='speak:text'){
-          speakWithAudio((ev.data||{}).text||'');
-        }else if(t==='speak:backchannel'){
-          // P2: tiny vocal grunt — non-blocking, ducks pads briefly.
-          const phrases=['mm','right','go on','yeah','uh-huh','ok'];
-          speakBrowser(phrases[Math.floor(Math.random()*phrases.length)]);
-        }else if(t==='llm:confidence'){
-          // P10: pulse swarm with model confidence (0..1).
-          const c=Number((ev.data||{}).c||0.5);
-          swarmSignal('confidence',{c});
-        }else if(t==='scan:complete'){
-          ringPulses.push({r:1,maxR:Math.min(W,H)*0.25,a:0.35,col:'#1a3a1a'});
+    }
+
+    async function sendMessage(text) {
+      addMessage('user', text);
+      updateThinking(true);
+      // SSE connection
+      const token = new URLSearchParams(window.location.search).get('token') || '';
+      const url = `/chat/message?token=${encodeURIComponent(token)}`;
+      const eventSource = new EventSource(`${url}&message=${encodeURIComponent(text)}`);
+      let assistantDiv = null;
+      let fullText = '';
+
+      eventSource.onmessage = (event) => {
+        if (!assistantDiv) {
+          assistantDiv = addMessage('assistant', '');
+          assistantDiv.classList.add('thinking');
+        }
+        const data = JSON.parse(event.data);
+        if (data.chunk) {
+          fullText += data.chunk;
+          assistantDiv.querySelector('.text').textContent = fullText;
+          messagesDiv.scrollTop = messagesDiv.scrollHeight;
+        }
+        if (data.done) {
+          assistantDiv.classList.remove('thinking');
+          updateThinking(false);
+          eventSource.close();
         }
       };
-      es.onerror=function(){ try{ es.close(); }catch(_){} };
-    })();
+      eventSource.onerror = () => {
+        if (assistantDiv) assistantDiv.classList.remove('thinking');
+        updateThinking(false);
+        eventSource.close();
+      };
+    }
+
+    inputLine.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && inputLine.value.trim()) {
+        sendMessage(inputLine.value.trim());
+        inputLine.value = '';
+      }
+    });
+
+    // ─── Mobile sensors ─────────────────────────────────────────────
+    if (window.DeviceOrientationEvent) {
+      window.addEventListener('deviceorientation', (event) => {
+        if (event.gamma !== null) {
+          // tilt left-right affects particle drift bias
+          const tilt = event.gamma / 90; // -1 to 1
+          // modify global drift factor (applied in particle update via wind)
+          window._tiltX = tilt * 0.2;
+        }
+      });
+    }
+    // Ambient light sensor
+    if ('AmbientLightSensor' in window) {
+      try {
+        const sensor = new AmbientLightSensor();
+        sensor.onreading = () => {
+          const brightness = Math.min(sensor.illuminance / 400, 1);
+          document.documentElement.style.opacity = 0.7 + brightness * 0.3;
+        };
+        sensor.start();
+      } catch (e) { /* not supported */ }
+    }
+
+    // Speech recognition (optional, tap and hold input to activate voice)
+    let recognition = null;
+    if ('SpeechRecognition' in window || 'webkitSpeechRecognition' in window) {
+      const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+      recognition = new SpeechRecognition();
+      recognition.continuous = false;
+      recognition.interimResults = false;
+      recognition.onresult = (event) => {
+        const transcript = event.results[0][0].transcript.trim();
+        if (transcript) {
+          inputLine.value = transcript;
+          sendMessage(transcript);
+        }
+      };
+      // long press input to activate voice
+      inputLine.addEventListener('pointerdown', startVoiceTimer);
+      inputLine.addEventListener('pointerup', cancelVoiceTimer);
+    }
+    let voiceTimer;
+    function startVoiceTimer(e) {
+      voiceTimer = setTimeout(() => {
+        if (recognition) recognition.start();
+      }, 600);
+    }
+    function cancelVoiceTimer() {
+      clearTimeout(voiceTimer);
+    }
+
+    // ─── Boot sequence ──────────────────────────────────────────────
+    function boot() {
+      showFace(3000); // face appears for 3 seconds
+      initAudio();
+      // initial message
+      addMessage('assistant', 'master ready');
+    }
+    boot();
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a new single-page, Zen‑minimal chat UI that replaces the previous chat view with a dark monochrome canvas and subtle sensory affordances.
- Present MASTER as a living, responsive surface: particles coalesce into a wireframe face on boot, pulse to audio, and reflect “thinking” state without traditional chrome.
- Simplify the interaction model to a hairline input (no visible buttons) while preserving streaming LLM output and optional voice/sensor inputs.

### Description
- Replaced the chat template at `MASTER/web/app/views/chat/index.html.erb` with a self-contained HTML/CSS/JS single‑page interface implementing the new design.
- Added a canvas particle engine (2,500 1px particles) with a generated wireframe face attractor, timed release, and an animation loop driven by `requestAnimationFrame`.
- Implemented SSE streaming to `/chat/message` with incremental chunk rendering, assistant “thinking” visuals (thin glowing left border + accent shift), and a boot message (`master ready`).
- Added optional sensory and audio features: an `AudioContext` ambient pad + `AnalyserNode` for particle jitter, `DeviceOrientation` tilt bias, `AmbientLightSensor` opacity adaptation, and Web Speech long‑press recognition for voice input.

### Testing
- Ran repository discovery and inspected bootstrap docs with `rg --files -g 'AGENTS.md'` and `cat AGENTS.md`, both of which completed successfully.
- Verified the target view file was written at `MASTER/web/app/views/chat/index.html.erb` and contains the new UI code.
- Attempted to run the repo orientation/scan tooling with `bundle exec ruby exe/master orient` and `bundle exec ruby exe/master` scans, but those commands failed here due to missing bundler/dependency checkout for a git source (`rb-edge-tts`) and/or missing `Gemfile` at the invoked path, so automated repo scans could not be completed in this environment.
- Attempted to restart the running service with `doas rcctl restart master`, but `doas` is not available in this container so that step could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe11903400832aa1f9c345df3cbd7f)