### PR TITLE
feat: add Rails/OpenBSD/Zsh constitutional data, SchemaIndex, and Rails scan rules

### DIFF
--- a/MASTER/data/gems.yml
+++ b/MASTER/data/gems.yml
@@ -1,0 +1,15 @@
+gems:
+  devise:
+    purpose: "Authentication framework"
+    common_mistakes:
+      - "custom routes without devise_for"
+      - "forgetting :lockable for rate limiting"
+  pundit:
+    purpose: "Authorization"
+    common_mistakes:
+      - "policy not scoped to current_user"
+      - "missing verify_authorized"
+  pagy:
+    purpose: "Pagination"
+    common_mistakes:
+      - "using Pagy::DEFAULT instead of Pagy::OPTIONS (43.x change)"

--- a/MASTER/data/openbsd.yml
+++ b/MASTER/data/openbsd.yml
@@ -85,3 +85,19 @@ configs:
     man: unbound.conf.5
     required_patterns:
       - "server:"
+
+
+system_health_checks:
+  - name: "patch_level"
+    command: "syspatch -c"
+    expected: ""
+  - name: "disk_usage"
+    command: "df -h /"
+    max_percent: 80
+
+service_definitions:
+  master:
+    service: "master"
+    check: "rcctl check master"
+    restart: "doas rcctl restart master"
+    logs: "/var/log/master.log"

--- a/MASTER/data/rails.yml
+++ b/MASTER/data/rails.yml
@@ -1,0 +1,55 @@
+stack:
+  rails: "8.1.3"
+  ruby: "3.3+"
+  database: "sqlite3 (default), PostgreSQL (production)"
+  server: "Falcon (rackup --server falcon)"
+  frontend: "Hotwire (Turbo + Stimulus)"
+  queue: "Solid Queue"
+  cache: "Solid Cache"
+  cable: "Solid Cable"
+  asset_pipeline: "Propshaft"
+
+patterns:
+  querying:
+    - "Always eager-load with #includes when iterating associations"
+    - "Use #strict_loading_by_default on all AR models"
+    - "Use #with_rich_text_#{name} and #with_attached_#{name} scopes"
+    - "Prefer #find_each / #in_batches over #each for large datasets"
+    - "Use #pluck / #pick for single-column queries"
+    - "Use #exists? over #present? on relations"
+    - "Use #update_all / #delete_all for bulk operations with callbacks understood"
+    - "Never use #find_or_create_by without a unique index in a migration"
+  controllers:
+    - "Keep controllers thin — business logic in models or service objects"
+    - "Use #current_attributes for request-scoped state, not class variables"
+    - "Return early with #head :ok or #redirect_to in guard clauses"
+    - "Use strong parameters with #require and #permit — never bare #params"
+    - "Rescue ActiveRecord::RecordNotFound with #rescue_from in ApplicationController"
+  views:
+    - "Use partials with locals: over instance variables"
+    - "Use tag./class_names helpers, never raw HTML strings"
+    - "Prefer Turbo Streams over custom JavaScript for reactivity"
+    - "Use #dom_id and #dom_class for stable DOM identifiers"
+    - "Localize all user-facing strings with I18n.t"
+  models:
+    - "Use #has_secure_password for authentication"
+    - "Use #enum with #validate: true"
+    - "Use #normalizes for attribute normalization"
+  testing:
+    - "Use Minitest with parallelize"
+    - "Use #travel_to for time-sensitive tests"
+    - "Assert #assert_enqueued_with for job testing"
+  background_jobs:
+    - "Always make jobs idempotent"
+    - "Use #retry_on with exponential backoff"
+    - "Use #discard_on for expected failures"
+  caching:
+    - "Use Russian Doll caching (#cache) with #touch on associations"
+    - "Use low-level caching (Rails.cache.fetch) for expensive computations"
+    - "Set #expires_in with clear TTLs"
+  security:
+    - "Use #authenticate_by for login (Rails 8 built-in auth)"
+    - "Use #rate_limit for brute-force protection"
+    - "Use #password_challenge for sensitive actions"
+    - "Always use #current_user, never #User.find(session[:user_id])"
+    - "Use #sanitize for user-generated HTML; never #html_safe on user input"

--- a/MASTER/data/ruby_semantics.yml
+++ b/MASTER/data/ruby_semantics.yml
@@ -1,0 +1,20 @@
+performance_patterns:
+  - id: "map_flatten_vs_flat_map"
+    description: "Use flat_map instead of map{...}.flatten"
+    detect: "\\.map\\(.*\\)\\.flatten"
+    fix: "replace with flat_map"
+
+metaprogramming_dangers:
+  - id: "method_missing_no_respond_to_missing"
+    description: "method_missing without respond_to_missing? breaks #respond_to? and #method"
+    severity: "warning"
+
+memory_patterns:
+  - id: "class_variable_inheritance"
+    description: "Class variables (@@var) share state across inheritance tree — prefer class instance variables"
+    severity: "error"
+
+concurrency_patterns:
+  - id: "memoization_not_thread_safe"
+    description: "@x ||= y is not thread-safe in shared mutable objects"
+    severity: "warning"

--- a/MASTER/data/zsh.yml
+++ b/MASTER/data/zsh.yml
@@ -1,0 +1,18 @@
+banned_commands:
+  sed: "${var//old/new}"
+  awk: "${${(s:,:)line}[4]}"
+  grep: "${(M)arr:#*pattern*}"
+  wc: "${#lines}"
+  head: "${arr[1,10]}"
+  tail: "${arr[-10,-1]}"
+  cut: "${${(s:,:)var}[3]}"
+  find: "**/*.rb(.)"
+  sudo: "doas"
+
+token_economics:
+  philosophy: "Single-grammar transforms reduce process boundaries and token overhead."
+  bad: "awk -F, '{print $4}' | sed 's/\\r//g' | tr '[:upper:]' '[:lower:]'"
+  good: "lower=${(L)${${(s:,:)line}[4]//$'\\r'/}}"
+
+ssh_reading:
+  rule: "cat path — read the whole file once, never stitch with grep|head|tail"

--- a/MASTER/lib/master/scan/rules/controller_bloat_rule.rb
+++ b/MASTER/lib/master/scan/rules/controller_bloat_rule.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Master
+  module Scan
+    module Rules
+      class ControllerBloatRule < Rule
+        def initialize
+          super
+          @id = "controller_bloat"
+          @description = "Controllers with too many actions are hard to evolve"
+          @severity = :warning
+          @axiom_tags = %i[COHESION]
+        end
+
+        def check(code, path:)
+          return [] unless path.include?("/app/controllers/") && path.end_with?(".rb")
+          actions = code.scan(/^\s*def\s+\w+/)
+          return [] if actions.size <= 7
+          [finding(line: 1, message: "controller defines #{actions.size} actions; split by namespace/service")]
+        end
+      end
+    end
+  end
+end

--- a/MASTER/lib/master/scan/rules/hotwire_pattern_rule.rb
+++ b/MASTER/lib/master/scan/rules/hotwire_pattern_rule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Master
+  module Scan
+    module Rules
+      class HotwirePatternRule < Rule
+        def initialize
+          super
+          @id = "hotwire_pattern"
+          @description = "Flags heavy Hotwire anti-patterns"
+          @severity = :warning
+          @axiom_tags = %i[PERFORMANCE]
+        end
+
+        def check(code, path:)
+          return [] unless path.end_with?(".erb") || path.end_with?(".js")
+          findings = []
+          code.each_line.with_index(1) do |line, line_number|
+            findings << finding(line: line_number, message: "prefer turbo-frame/turbo-stream over manual fetch") if line.include?("fetch(")
+            findings << finding(line: line_number, message: "form is missing turbo-frame binding") if line.include?("form_with") && !line.include?("turbo_frame")
+          end
+          findings
+        end
+      end
+    end
+  end
+end

--- a/MASTER/lib/master/scan/rules/i18n_coverage_rule.rb
+++ b/MASTER/lib/master/scan/rules/i18n_coverage_rule.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Master
+  module Scan
+    module Rules
+      class I18nCoverageRule < Rule
+        LITERAL_TEXT = />\s*[A-Za-z][^<]{3,}</.freeze
+
+        def initialize
+          super
+          @id = "i18n_coverage"
+          @description = "Views should wrap user-facing literals in I18n helpers"
+          @severity = :warning
+          @axiom_tags = %i[ABSTRACTION]
+        end
+
+        def check(code, path:)
+          return [] unless path.include?("/app/views/") && path.end_with?(".erb")
+          scan_lines(code, LITERAL_TEXT, message: "possible hardcoded UI string; use t('.key')")
+        end
+      end
+    end
+  end
+end

--- a/MASTER/lib/master/scan/rules/migration_safety_rule.rb
+++ b/MASTER/lib/master/scan/rules/migration_safety_rule.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Master
+  module Scan
+    module Rules
+      class MigrationSafetyRule < Rule
+        def initialize
+          super
+          @id = "migration_safety"
+          @description = "Flags unsafe migration patterns"
+          @severity = :error
+          @axiom_tags = %i[ROBUSTNESS]
+        end
+
+        def check(code, path:)
+          return [] unless path.include?("/db/migrate/") && path.end_with?(".rb")
+          findings = []
+          code.each_line.with_index(1) do |line, line_number|
+            findings << finding(line: line_number, message: "add_reference without foreign_key: true") if line.include?("add_reference") && !line.include?("foreign_key:")
+            findings << finding(line: line_number, message: "remove_column is destructive; document safety/backfill path") if line.include?("remove_column")
+            findings << finding(line: line_number, message: "find_or_create_by requires backing unique index") if line.include?("find_or_create_by")
+          end
+          findings
+        end
+      end
+    end
+  end
+end

--- a/MASTER/lib/master/scan/rules/query_plan_rule.rb
+++ b/MASTER/lib/master/scan/rules/query_plan_rule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Master
+  module Scan
+    module Rules
+      class QueryPlanRule < Rule
+        def initialize
+          super
+          @id = "query_plan"
+          @description = "Query shapes likely to degrade at scale"
+          @severity = :warning
+          @axiom_tags = %i[PERFORMANCE]
+        end
+
+        def check(code, path:)
+          return [] unless path.end_with?(".rb") && (path.include?("/app/models/") || path.include?("/app/controllers/"))
+          findings = []
+          code.each_line.with_index(1) do |line, line_number|
+            findings << finding(line: line_number, message: "prefer scoped count over full-table count") if line.match?(/\.count\s*$/)
+            findings << finding(line: line_number, message: "limit selected columns on wide joins") if line.include?(".joins(") && !line.include?(".select(")
+          end
+          findings
+        end
+      end
+    end
+  end
+end

--- a/MASTER/lib/master/scan/rules/rate_limiting_rule.rb
+++ b/MASTER/lib/master/scan/rules/rate_limiting_rule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Master
+  module Scan
+    module Rules
+      class RateLimitingRule < Rule
+        SENSITIVE = /(login|signup|sign_up|password|reset)/i.freeze
+
+        def initialize
+          super
+          @id = "rate_limiting"
+          @description = "Sensitive endpoints should enforce rate limiting"
+          @severity = :error
+          @axiom_tags = %i[SECURITY]
+        end
+
+        def check(code, path:)
+          return [] unless path.include?("/app/controllers/") && path.end_with?(".rb")
+          return [] unless path.match?(SENSITIVE) || code.match?(SENSITIVE)
+          return [] if code.include?("rate_limit") || code.include?("throttle")
+          [finding(line: 1, message: "add rate_limit/throttle protection for sensitive controller actions")]
+        end
+      end
+    end
+  end
+end

--- a/MASTER/lib/master/schema_index.rb
+++ b/MASTER/lib/master/schema_index.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Master
+  class SchemaIndex
+    attr_reader :tables
+
+    def initialize(root:)
+      @root = root
+      @tables = {}
+      parse_schema
+    end
+
+    def indexed_columns(table_name)
+      (@tables.dig(table_name, :indexes) || []).flat_map { |idx| idx[:columns] }
+    end
+
+    def columns(table_name)
+      (@tables.dig(table_name, :columns) || [])
+    end
+
+    private
+
+    def parse_schema
+      path = File.join(@root, "db", "schema.rb")
+      return unless File.exist?(path)
+      table_name = nil
+      File.readlines(path, chomp: true).each do |line|
+        if line =~ /^\s*create_table\s+"([^"]+)"/
+          table_name = Regexp.last_match(1)
+          @tables[table_name] = { columns: [], indexes: [] }
+        elsif table_name && line =~ /^\s*t\.\w+\s+"([^"]+)"/
+          @tables[table_name][:columns] << Regexp.last_match(1)
+        elsif line =~ /^\s*add_index\s+"([^"]+)",\s+\[(.+)\]/
+          target = Regexp.last_match(1)
+          cols = Regexp.last_match(2).scan(/"([^"]+)"/).flatten
+          (@tables[target] ||= { columns: [], indexes: [] })[:indexes] << { columns: cols }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

- Provide a canonical, boot-time Rails knowledge source and ecosystem guidance so MASTER can apply deterministic, domain-aware checks instead of ad-hoc prompts.
- Add schema-awareness and new Rails-focused static checks to catch scale, migration, i18n, Hotwire, and security issues earlier.
- Strengthen platform awareness (Zsh discipline and OpenBSD health/service metadata) so shell actions and platform audits follow the repo's constitutional rules.

### Description

- Add domain knowledge YAMLs: `MASTER/data/rails.yml`, `MASTER/data/ruby_semantics.yml`, `MASTER/data/gems.yml`, and `MASTER/data/zsh.yml` to hold Rails patterns, Ruby semantics, gem guidance, and Zsh discipline respectively.
- Extend `MASTER/data/openbsd.yml` with `system_health_checks` and `service_definitions` to enable boot-time and pre-deploy platform validations.
- Implement `Master::SchemaIndex` in `MASTER/lib/master/schema_index.rb` to parse `db/schema.rb` and expose `indexed_columns`/`columns` for schema-aware rules.
- Add Rails-specific scan rules under `MASTER/lib/master/scan/rules/`: `MigrationSafetyRule`, `QueryPlanRule`, `RateLimitingRule`, `HotwirePatternRule`, `I18nCoverageRule`, and `ControllerBloatRule`, which inherit `Scan::Rule` and therefore auto-register via the existing `Rule.inherited` hook.
- Keep changes focused on deterministic, local checks (regex/AST-friendly) and data-driven policy files so MASTER can inject the relevant slices at runtime when a Rails project or shell/OpenBSD task is detected.

### Testing

- Ran Ruby syntax checks with `ruby -c` for `MASTER/lib/master/schema_index.rb` and the new scan rules and they reported `Syntax OK`.
- Performed repository staging and a commit which succeeded and recorded the new files and changes (commit message: `feat: add rails and platform constitutional extensions`).
- Attempting to run `bundle exec ruby exe/master orient` in this environment failed due to missing Bundler git dependency (`rb-edge-tts` checkout), so a full boot/integration validation was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe135a5cc8832a9d1d6669e9953286)