### PR TITLE
Expand MASTER test coverage scaffolding and add core unit suites

### DIFF
--- a/MASTER/Gemfile
+++ b/MASTER/Gemfile
@@ -28,6 +28,7 @@ group :test do
   gem "minitest", "~> 5.25"
   gem "rack-test", "~> 2.1"
   gem "ferrum", "~> 0.15"
+  gem "simplecov", require: false
 end
 gem "ruby_llm-mcp"
 gem "rubocop", "~> 1.60", require: false

--- a/MASTER/Rakefile
+++ b/MASTER/Rakefile
@@ -42,3 +42,10 @@ task :constitution do
 end
 
 task default: :test
+
+namespace :test do
+  desc "Run web system tests"
+  task :web do
+    sh "ruby -Ilib:test test/test_web_ui.rb"
+  end
+end

--- a/MASTER/test/fixtures_bare_rescue.rb
+++ b/MASTER/test/fixtures_bare_rescue.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module TestFixture
+  def risky_read
+    File.read("/tmp/x")
+  rescue
+    nil
+  end
+end

--- a/MASTER/test/test_bare_rescue_rule.rb
+++ b/MASTER/test/test_bare_rescue_rule.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestBareRescueRule < Minitest::Test
+  def setup
+    @rule = Master::Scan::Rules::BareRescueRule.new
+  end
+
+  def test_detects_bare_rescue
+    code = File.read(File.join(__dir__, "fixtures_bare_rescue.rb"))
+
+    findings = @rule.check(code, path: "test/fixtures_bare_rescue.rb")
+
+    refute_empty findings
+    assert_equal "bare_rescue", findings.first[:rule]
+    assert_match(/specify exception type/, findings.first[:message])
+  end
+
+  def test_passes_when_rescue_names_exception
+    code = <<~RUBY
+      def safe
+        do_work
+      rescue StandardError => e
+        warn e.message
+      end
+    RUBY
+
+    findings = @rule.check(code, path: "safe.rb")
+
+    assert_empty findings
+  end
+end

--- a/MASTER/test/test_council_deliberation.rb
+++ b/MASTER/test/test_council_deliberation.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestCouncilDeliberation < Minitest::Test
+  Persona = Struct.new(:name, :role, :bias, :prompt, :veto_role, :emphasizes, keyword_init: true) do
+    def veto? = !!veto_role
+  end
+
+  class StubAgent
+    def initialize(mapping = {})
+      @mapping = mapping
+    end
+
+    def ask(prompt)
+      @mapping.each do |needle, response|
+        return response if prompt.include?(needle)
+      end
+      "looks good"
+    end
+  end
+
+  def test_veto_blocks_review
+    personas = [
+      Persona.new(name: "Security", role: "Attacker", bias: "paranoid", prompt: "be strict", veto_role: true)
+    ]
+    agent = StubAgent.new("You are Security" => "VETO: unsafe eval path")
+
+    result = Master::Council::Deliberation.new(personas:, agent:, judge_enabled: false)
+                                        .review("eval(params[:x])")
+
+    assert result.err?
+    assert_equal :validation, result.category
+    assert_match(/veto/i, result.message)
+  end
+
+  def test_empty_personas_fails_validation
+    result = Master::Council::Deliberation.new(personas: [], agent: StubAgent.new, judge_enabled: false)
+                                        .review("puts :ok")
+
+    assert result.err?
+    assert_equal :validation, result.category
+    assert_match(/no personas/, result.message)
+  end
+end

--- a/MASTER/test/test_helper.rb
+++ b/MASTER/test/test_helper.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+if ENV["COVERAGE"] == "1"
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/test/"
+    add_group "Scan", "lib/master/scan"
+    add_group "Stages", "lib/master/stages"
+    add_group "Council", "lib/master/council"
+    minimum_coverage 85
+  end
+end
+
 require "minitest/autorun"
 require "tmpdir"
 require "timeout"

--- a/MASTER/test/test_learnings.rb
+++ b/MASTER/test/test_learnings.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestLearnings < Minitest::Test
+  def test_record_and_search_prefers_non_failed_entries
+    Dir.mktmpdir do |dir|
+      learnings = Master::Learnings.new(root: dir)
+      learnings.record(trigger: "rubocop offense", strategy: "run autocorrect", outcome: :fixed)
+      learnings.record(trigger: "rubocop offense", strategy: "ignore", outcome: :failed)
+
+      hits = learnings.search("rubocop")
+
+      refute_empty hits
+      assert_equal "run autocorrect", hits.first["strategy"]
+      refute_includes hits.map { |h| h["outcome"] }, "failed"
+    end
+  end
+
+  def test_opportunities_identifies_failure_and_corrections
+    Dir.mktmpdir do |dir|
+      learnings = Master::Learnings.new(root: dir)
+      3.times { learnings.record_event(event_type: :tool_failure, dimension: "write_file") }
+      3.times { learnings.record_event(event_type: :user_correction, dimension: "style") }
+      3.times { learnings.record_event(event_type: :provider_error, dimension: "openrouter") }
+
+      categories = learnings.opportunities.map { |o| o[:category] }
+
+      assert_includes categories, :high_failure
+      assert_includes categories, :repeated_correction
+      assert_includes categories, :provider_errors
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
- Increase automated test coverage for core MASTER subsystems (scan rules, council, learnings) to reduce silent regressions and enable CI coverage reporting.
- Provide fixture-driven, deterministic unit tests that can be used as templates for adding more rule tests and for MASTER-generated test scaffolding.

### Description
- Added a fixture and unit tests for the `BareRescueRule` to detect bare `rescue` and to assert a typed-rescue passes (`test/fixtures_bare_rescue.rb`, `test/test_bare_rescue_rule.rb`).
- Added deterministic tests for `Council::Deliberation` to verify veto behavior and validation when no personas are provided (`test/test_council_deliberation.rb`).
- Added tests for `Learnings` covering ledger recording/search and RSI opportunity detection (`test/test_learnings.rb`).
- Added optional coverage instrumentation gated by environment variable in `test/test_helper.rb` and added `simplecov` to the `:test` group in the Gemfile so CI/local runs can enable coverage with `COVERAGE=1`.
- Added a short `rake test:web` task to the `Rakefile` as an entry point for web/system test execution.

### Testing
- Ran the new unit tests via direct commands such as `ruby -Ilib:test test/test_bare_rescue_rule.rb`, `ruby -Ilib:test test/test_council_deliberation.rb`, and `ruby -Ilib:test test/test_learnings.rb`; all attempts were blocked by missing runtime gems (environment lacked required dependencies such as `zeitwerk`), so tests could not complete here (failed).
- Adjusted `test/test_helper.rb` to load `simplecov` only when `COVERAGE=1` to avoid forcing coverage tooling in environments without the test gems (no coverage run was performed due to the same missing dependency issue).
- No CI run was executed in this environment; tests are expected to pass in a properly provisioned environment after `bundle install`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe174b1028832ab734a04bca6cdd54)