### PR TITLE
Remove stale scan rule references from scanner bootstrap

### DIFF
--- a/MASTER/lib/master/builder/infra_helpers.rb
+++ b/MASTER/lib/master/builder/infra_helpers.rb
@@ -7,9 +7,6 @@ module Master
     def build_scanner(root:, agent:, bus:)
       scanner = Judge::Scan::Scanner.new(event_bus: bus)
       Judge::Scan::Rule.registry.select(&:auto_build?).each { |klass| scanner.add_rule(klass.new) }
-      scanner.add_rule(Judge::Scan::Rules::RuleCoverageRule.new(root:))
-      scanner.add_rule(Judge::Scan::Rules::RubocopRule.new(root:))
-      scanner.add_rule(Judge::Scan::Rules::ReekRule.new(root:))
       scanner.add_rule(Judge::Scan::Rules::InterconnectRule.new(root:))
       scanner.add_rule(Judge::Scan::Rules::SemanticRule.new(agent:))
       scanner.add_rule(Judge::Scan::Rules::AdversarialRule.new(agent:))


### PR DESCRIPTION
### Motivation
- Running `ruby exe/master` failed with an uninitialized constant for `RuleCoverageRule` because the scanner bootstrap referenced rule classes that no longer exist, so the scanner needs to only register rules that are present.

### Description
- Removed explicit registration of `RuleCoverageRule`, `RubocopRule`, and `ReekRule` from `MASTER/lib/master/builder/infra_helpers.rb` so the scanner relies on auto-built registry rules and the existing explicit rules (`InterconnectRule`, `SemanticRule`, `AdversarialRule`, `CommentDriftRule`).
- Kept the call to `Judge::Scan::Rule.registry.select(&:auto_build?)` so table-driven and YAML-defined rules remain auto-registered.

### Testing
- Ran `ruby exe/master` in `MASTER/` and confirmed the original `RuleCoverageRule` NameError no longer appears, but startup now fails later due to a missing runtime gem (`zeitwerk`).
- Attempted `bundle exec ruby exe/master orient` but it could not complete in this environment due to bundler/git dependency checkout issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049fc01a3883298bfc2f900b6b3690)