### PR TITLE
Add modular Face3D particle engine

### DIFF
--- a/MASTER/data/repo_topic_clusters.yml
+++ b/MASTER/data/repo_topic_clusters.yml
@@ -1,0 +1,259 @@
+# MASTER repo topic clusters
+# Mined from anon987654321/pub4 plus public GitHub/arXiv/ar5iv-adjacent search.
+---
+
+clusters:
+  - id: token_efficiency
+    name: Token Efficiency and Context Conservation
+    status: live
+    confidence: high
+    local_evidence:
+      - MASTER/knowledge/research/token_reduction.md
+      - MASTER/docs/provider_economy.md
+      - MASTER/data/budget.yml
+      - MASTER/data/models.yml
+    external_evidence:
+      - arxiv:2604.09613 Token-Budget-Aware Pool Routing for Cost-Efficient LLM Inference
+      - arxiv:2604.08075 Dual-Pool Token-Budget Routing for Cost-Efficient and Reliable LLM Serving
+      - arxiv:2410.10456 Ada-K Routing: Boosting the Efficiency of MoE-based LLMs
+    pattern: >
+      Estimate cost before acting. Route by token budget, task risk, provider health,
+      and context pressure. Speak only when output adds value.
+    build_next:
+      - Token budget predictor for MASTER requests.
+      - Silent-success default for cluster mining and visual telemetry.
+      - Cheap-model route for summarization, classification, critique, and cluster labels.
+
+  - id: free_model_fallbacks
+    name: Free Model Fallbacks and Provider Economy
+    status: live
+    confidence: high
+    local_evidence:
+      - MASTER/data/models.yml
+      - MASTER/docs/provider_economy.md
+      - MASTER/data/budget.yml
+      - MASTER/lib/now/routing/model_router.rb
+      - MASTER/lib/reach/circuit_breaker.rb
+    pattern: >
+      Treat providers as competing infrastructure. Use free/local/cheap models for
+      low-risk work, escalate only for irreversible synthesis, and quarantine weak providers.
+    build_next:
+      - Provider health scoreboard.
+      - Failure-triggered visual events.
+      - Model fallback simulator.
+
+  - id: design_architecture_systems
+    name: Design, Architecture, and System Shape
+    status: live
+    confidence: high
+    local_evidence:
+      - MASTER/data/architectures.yml
+      - MASTER/data/workflow.yml
+      - MASTER/docs/repo_ecology.md
+      - MASTER/docs/cognitive_runtime.md
+      - DEPLOY/rails/amber/ARCHITECTURE.md
+    pattern: >
+      MASTER already thinks in architectures: rule DAGs, dataflow pipelines,
+      CRDT convergence, Bayesian priors, repo ecology, and embodied codebase topology.
+    build_next:
+      - Architecture Pattern Atlas.
+      - Design Critique Council.
+      - System-shape visualization linked to codebase topology.
+
+  - id: webgpu_browser_runtime
+    name: WebGPU Browser Runtime
+    status: new_external
+    confidence: high
+    external_evidence:
+      - arxiv:2412.15803 WebLLM: A High-Performance In-Browser LLM Inference Engine
+      - arxiv:2604.02344 Characterizing WebGPU Dispatch Overhead for LLM Inference
+      - github:mlc-ai/web-llm
+    pattern: >
+      Browser-local inference is becoming a viable runtime tier. WebGPU allows
+      private, local, low-friction inference, but dispatch overhead and kernel fusion matter.
+    build_next:
+      - Optional browser-local assistant mode.
+      - WebGPU particle renderer for Face3D.
+      - WebLLM fallback route for offline cheap cognition.
+
+  - id: webgpu_world_model_rendering
+    name: WebGPU World Models and Neural Rendering
+    status: new_external
+    confidence: high
+    external_evidence:
+      - arxiv:2512.08478 Visionary: WebGPU-Powered Gaussian Splatting Platform
+      - arxiv:2409.06765 gsplat: An Open-Source Library for Gaussian Splatting
+      - arxiv:2311.12775 SuGaR: Surface-Aligned Gaussian Splatting
+    pattern: >
+      Gaussian splats, meshes, and per-frame neural processing can become the next
+      Face3D backend: semantic particles today, neural splats tomorrow.
+    build_next:
+      - Face3D WebGPU renderer spike.
+      - Gaussian-splat avatar/world renderer experiment.
+      - Repository terrain as navigable 3D scene.
+
+  - id: openclaw_like_personal_agents
+    name: OpenClaw-like Personal Agents
+    status: new_external
+    confidence: medium
+    unresolved_terms:
+      - opencrabs: not found clearly in public search; may be private, misspelled, or meant as OpenClaw/OpenCrab-like.
+    external_evidence:
+      - openclaw/openclaw Personal AI assistant pattern
+      - arxiv:2604.11548 SemaClaw harness engineering for personal AI agents
+      - arxiv:2603.10165 OpenClaw-RL next-state learning from user/tool/GUI signals
+      - KroMiose/nekro-agent chat-platform sandboxed agent pattern
+      - crewAIInc/crewAI multi-agent workflow pattern
+    pattern: >
+      Persistent personal agents need harness engineering: permissions, sandboxing,
+      task queues, memory, tool safety, user feedback learning, and reliable rollback.
+    build_next:
+      - MASTER Harness Layer.
+      - PermissionBridge equivalent for tools/files/calendar/mail.
+      - Agent skill sandbox with signed/verified skills only.
+
+  - id: bleeding_edge_experimental_repos
+    name: Bleeding Edge Experimental Repos
+    status: new_external
+    confidence: medium
+    external_evidence:
+      - openclaw/openclaw autonomous personal agent
+      - Gen-Verse/OpenClaw-RL online RL for agents
+      - mlc-ai/web-llm browser-local WebGPU LLM inference
+      - nerfstudio-project/gsplat Gaussian splatting development library
+      - vllm-project/vllm high-throughput inference serving
+      - sgl-project/sglang structured generation and serving
+      - ggml-org/llama.cpp edge/local inference
+      - KroMiose/nekro-agent multimodal/chat-platform agent framework
+    pattern: >
+      Experimental repos cluster around local inference, persistent agents,
+      structured generation, sandboxed skills, multimodal UI, and GPU-native web runtimes.
+    build_next:
+      - External Repo Radar.
+      - Weekly cluster diff of fast-moving repos.
+      - Risk tags: security, licensing, stability, hype, reproducibility.
+
+  - id: agi_agent_ecosystem
+    name: AGI, Agents, and Multi-Agent Ecosystem
+    status: mirrored_research
+    confidence: high
+    local_evidence:
+      - github_repos/awesome-ai-agents/README.md
+      - github_repos/awesome-llm-apps/mcp_ai_agents/multi_mcp_agent/multi_mcp_agent.py
+      - MASTER/lib/judge/agent.rb
+      - MASTER/docs/cognitive_runtime.md
+    pattern: >
+      The repo contains a mirrored agent landscape plus internal agent/council/runtime work.
+    build_next:
+      - Agent framework taxonomy.
+      - MASTER subsystem comparison matrix.
+      - Multi-agent orchestration pattern miner.
+
+  - id: personal_assistants
+    name: Personal Assistants and Voice Assistants
+    status: mirrored_research
+    confidence: high
+    local_evidence:
+      - github_repos/awesome-llm-apps/ai_agent_framework_crash_course/openai_sdk_crash_course/1_starter_agent/1_personal_assistant_agent/README.md
+      - github_repos/awesome-llm-apps/ai_agent_framework_crash_course/openai_sdk_crash_course/1_starter_agent/1_personal_assistant_agent/agent.py
+      - github_repos/system_prompts_leaks/Perplexity/voice-assistant.md
+      - github_repos/system_prompts_leaks/Perplexity/comet-browser-assistant.md
+      - MASTER/web/public/face.js
+    pattern: >
+      Personal assistants combine persistent context, speech, tools, calendar/mail/files,
+      interruption handling, and social presentation.
+    build_next:
+      - Assistant Mode Map.
+      - Voice-first flow for MASTER web UI.
+      - Safe prompt-pattern extraction without copying leaked prompt text.
+
+  - id: social_intelligence
+    name: Social Intelligence and Interaction Norms
+    status: latent
+    confidence: medium
+    local_evidence:
+      - github_repos/leaked-system-prompts/discord-clyde_20230420.md
+      - github_repos/leaked-system-prompts/discord-clyde_20230716-1.md
+      - github_repos/leaked-system-prompts/meta-ai-whatsapp_20250819.md
+      - github_repos/CL4R1T4S/META/Llama4_WhatsApp.txt
+      - MASTER/web/public/face.js
+    pattern: >
+      Social intelligence appears as prompt archaeology and expressive UI gestures,
+      but needs a safe first-party interaction policy layer.
+    build_next:
+      - Social Mode Controller.
+      - Rapport/repair/escalation state machine.
+      - Face3D social expression presets.
+
+  - id: music_chord_theory
+    name: Music, Chord Theory, and Production DNA
+    status: live
+    confidence: high
+    local_evidence:
+      - MASTER/lib/voice/production_dna.rb
+      - DEPLOY/dilla/dilla_analog.rb
+      - DEPLOY/dilla/dilla.rb
+      - DEPLOY/dilla/dilla.html
+    pattern: >
+      Dilla/Madlib/FlyLo timing, chord voicings, analog drift, low-pass warmth,
+      sampler grit, and live-triggered imperfection are encoded as reusable production DNA.
+    build_next:
+      - Music theory registry.
+      - Chord graph visualizer.
+      - Beat/voice prosody bridge.
+
+  - id: lyricism_linguistics
+    name: Lyricism, Linguistics, Prosody, and Voice
+    status: latent
+    confidence: medium
+    local_evidence:
+      - MASTER/knowledge/research/tts.yml
+      - MASTER/lib/voice/production_dna.rb
+      - MASTER/lib/voice/speech.rb
+      - MASTER/web/public/face.js
+    pattern: >
+      Speech style inference, sentence-level TTS, prosody research, visemes,
+      and musical timing point toward a lyricism/linguistics engine.
+    build_next:
+      - Phoneme/rhyme/meter extractor.
+      - Prosody-to-viseme mapping.
+      - Copyright-safe lyric constraints.
+
+  - id: embodied_exoskeletons
+    name: Embodied Interfaces, Exoskeletons, and Body Augmentation
+    status: speculative
+    confidence: low
+    local_evidence:
+      - MASTER/web/public/face.js
+      - MASTER/docs/repo_ecology.md
+      - MASTER/data/architectures.yml
+    pattern: >
+      No strong physical exoskeleton repo evidence was found yet. Existing evidence
+      points to a cognitive/interface exoskeleton: face, gestures, haptics, terrain,
+      body-like repo topology, and agentic control surfaces.
+    build_next:
+      - Haptics and motion input layer.
+      - Wearable/robotics repo search pass.
+      - Embodied cognition UI taxonomy.
+
+  - id: ar5iv_research_radar
+    name: ar5iv / arXiv Research Radar
+    status: new_external
+    confidence: medium
+    notes: >
+      Direct ar5iv HTML results were not exposed by search, but arXiv equivalents
+      were found for the requested themes and can usually be checked on ar5iv by ID.
+    external_evidence:
+      - arxiv:2512.08478 WebGPU Gaussian Splatting / Visionary
+      - arxiv:2412.15803 WebLLM browser inference
+      - arxiv:2604.09613 Token-budget pool routing
+      - arxiv:2604.08075 Dual-pool token-budget routing
+      - arxiv:2604.11548 SemaClaw harness engineering
+      - arxiv:2603.10165 OpenClaw-RL online agent learning
+      - arxiv:2604.02344 WebGPU dispatch overhead
+    pattern: >
+      Use ar5iv/arXiv as a research radar feeding MASTER's design backlog.
+    build_next:
+      - arXiv/ar5iv topic watchlist.
+      - Paper-to-cluster summarizer.
+      - Implementation-readiness scoring.

--- a/MASTER/data/visual_clusters.yml
+++ b/MASTER/data/visual_clusters.yml
@@ -1,0 +1,205 @@
+# MASTER visual and cognition clusters
+# Canonical registry for mining existing clusters and planning new ones.
+---
+
+clusters:
+  - id: face_particle_body
+    name: Face Particle Body
+    status: live
+    layer: embodiment
+    files:
+      - web/public/face.js
+      - web/public/face3d_engine.js
+      - web/public/face3d_renderer.js
+      - web/public/face3d_preview.js
+    signals:
+      - mood
+      - model
+      - verdict
+      - confidence
+      - tool
+      - tts
+      - stt
+      - gesture
+    purpose: >
+      Renders the assistant as a living mask/face. The current version is a retro
+      particle canvas; the Face3D modules add normalized topology, semantic zones,
+      blendshapes, typed-array particles, and preview rendering.
+    migration:
+      - Use Face3DPreview behind ?face3d=1.
+      - Move lipsync to duration-aware visemes.
+      - Convert existing 2D mask anchors to normalized 3D topology.
+      - Keep Atkinson/Bayer/ZX phosphor style as the default aesthetic.
+
+  - id: cognition_ecology
+    name: Cognition Ecology
+    status: live
+    layer: background_world
+    files:
+      - web/public/cognition_ecology.js
+    signals:
+      - master:visual
+      - entropy
+      - confidence
+      - provider
+      - topology
+    purpose: >
+      Renders cognitive terrain, weather, trails, memories, and agent spirits.
+      Runtime events become weather systems and semantic terrain impacts.
+    migration:
+      - Feed Face3D emotion vector from the same entropy/confidence/provider state.
+      - Let memory events spawn both ecology constellations and face crown halos.
+      - Share a single visual event normalizer with visual_bridge.
+
+  - id: codebase_topology
+    name: Codebase Particle Topology
+    status: live
+    layer: repository_body
+    files:
+      - web/public/codebase.js
+      - data/architectures.yml
+    signals:
+      - master:codebase
+      - master:rule_event
+      - codebase:topology
+      - rule_loop:cycle
+      - rule_loop:clean
+      - rule_loop:converged
+    purpose: >
+      Renders modules as particle clusters. Violations agitate clusters; fixes
+      settle them. This is Architecture #15 from the architecture registry.
+    migration:
+      - Promote module registry data into a reusable cluster graph.
+      - Connect dirty module agitation to face uncertainty and ecology terrain fractures.
+      - Add ReferenceGraph and SimilarityClusterer output when available.
+
+  - id: visual_bridge
+    name: Runtime Visual Bridge
+    status: live
+    layer: event_translation
+    files:
+      - web/public/visual_bridge.js
+    signals:
+      - events:stream
+      - DOM input
+      - DOM chat append
+      - status mutation
+    purpose: >
+      Classifies runtime events into visual mode, topology, entropy, confidence,
+      and provider, then emits master:visual plus codebase/rule events.
+    migration:
+      - Extract EVENT_MAP into data for reuse by face, ecology, and codebase views.
+      - Emit Face3D emotion patches directly.
+      - Preserve DOM reflection as a compatibility layer.
+
+  - id: speech_audio_body
+    name: Speech and Audio Body
+    status: partial
+    layer: voice
+    files:
+      - lib/voice/speech.rb
+      - bin/tts-worker
+      - web/public/face.js
+    signals:
+      - chat chunk
+      - sentence break
+      - tts queue
+      - analyser energy
+      - viseme
+    purpose: >
+      Turns assistant output into server-side speech, routes decoded audio through
+      the analyser, and reshapes the particle mouth while speech plays.
+    migration:
+      - Fix availability detection.
+      - Preserve audio mime type for MP3 versus WAV fallback.
+      - Use decoded audio duration and energy for viseme timing.
+      - Share VisemeDriver with Face3D.
+
+  - id: repo_ecology
+    name: Repo Ecology
+    status: planned
+    layer: repository_mining
+    files:
+      - docs/repo_ecology.md
+      - data/visual_clusters.yml
+    signals:
+      - scan
+      - classify
+      - cluster
+      - score
+      - simulate
+      - critique
+    purpose: >
+      Turns the repository into semantic topology, dependency ecology, cognitive
+      geography, architectural history, and organizational memory.
+    migration:
+      - Add cluster miner outputs as structured data.
+      - Feed similarity, reference, and dead-zone clusters into codebase topology.
+      - Keep every proposal reversible, scoped, and audited.
+
+new_clusters:
+  - id: cluster_miner
+    name: Cluster Miner
+    status: proposed
+    purpose: >
+      Scans file paths, runtime events, architecture registry, and repo ecology
+      notes to produce reusable clusters with confidence, evidence, and migration
+      candidates.
+    outputs:
+      - cluster_id
+      - members
+      - evidence
+      - confidence
+      - risks
+      - next_actions
+
+  - id: evidence_graph
+    name: Evidence Graph
+    status: proposed
+    purpose: >
+      Tracks why a file belongs to a cluster: imports, runtime events, shared
+      vocabulary, shared data files, changed-together history, or explicit docs.
+    outputs:
+      - source
+      - relation
+      - target
+      - weight
+      - reason
+
+  - id: emotion_bus
+    name: Emotion Bus
+    status: proposed
+    purpose: >
+      Converts visual_bridge entropy/confidence/mode/provider into a single
+      Face3D emotion vector shared by face, ecology, and codebase layers.
+    outputs:
+      - arousal
+      - valence
+      - focus
+      - confidence
+      - fatigue
+
+  - id: topology_registry
+    name: Topology Registry
+    status: proposed
+    purpose: >
+      Names all visual topologies in one place: papua-mask, serpent, neural,
+      torus, sphere, codebase, and future terrain/body forms.
+    outputs:
+      - topology_id
+      - renderer
+      - preferred_palette
+      - compatible_events
+
+  - id: migration_radar
+    name: Migration Radar
+    status: proposed
+    purpose: >
+      Watches the gap between current live behavior and Face3D target behavior.
+      Prioritizes small safe migrations that preserve the retro aesthetic.
+    outputs:
+      - migration_step
+      - touched_files
+      - blast_radius
+      - rollback_plan
+      - confidence

--- a/MASTER/docs/face3d_engine.md
+++ b/MASTER/docs/face3d_engine.md
@@ -1,0 +1,99 @@
+# Face3D particle system migration
+
+This document describes the incremental path from the current retro canvas face to a more coherent semantic 3D face-as-particles engine.
+
+## Goals
+
+- Keep the existing retro Atkinson/Bayer/ZX/phosphor look.
+- Move face geometry into normalized 3D coordinates.
+- Move expression logic into blendshape state.
+- Keep particles semantically assigned to anatomical zones.
+- Use typed arrays in hot loops.
+- Make speech, mood, confidence, tool events, and verdicts drive one coherent face state.
+
+## New module
+
+`web/public/face3d_engine.js` adds a standalone engine namespace at `window.MasterFace3D` and exports the same API as an ES module.
+
+The module is intentionally additive. It does not replace `face.js` yet.
+
+## Core concepts
+
+### Normalized topology
+
+Masks should produce anchors in normalized face space:
+
+- `x`: left to right, roughly `-1..1`
+- `y`: forehead to chin, roughly `-1..1`
+- `z`: back to forward, roughly `-1..1`
+- `zone`: semantic anatomical region
+- `u`: stable local coordinate within the zone
+
+This lets the same topology scale to any viewport and makes real 3D pose projection simpler.
+
+### Semantic particles
+
+Particles keep a stable zone and local `u` coordinate. During mask changes, each particle finds the corresponding anchor in the new mask rather than being randomly reassigned.
+
+This preserves feature identity: pupil particles stay pupils, mouth particles stay mouth, and brow particles stay brows.
+
+### Blendshape rig
+
+Mood, speech, confidence, and state events should write to blendshape values:
+
+- `blink`
+- `squint`
+- `browInnerUp`
+- `browDown`
+- `smile`
+- `frown`
+- `jawOpen`
+- `mouthWide`
+- `mouthRound`
+- `pupilDilate`
+- `nostrilFlare`
+- `cheekRaise`
+- `shock`
+- `chibi`
+
+Particle targets are produced by applying the blendshape rig to topology anchors.
+
+### Emotion vector
+
+High-level events should update one emotion vector:
+
+- `arousal`
+- `valence`
+- `focus`
+- `confidence`
+- `fatigue`
+
+Blendshapes are derived from this vector, so the face feels continuous rather than event-random.
+
+### Quality controller
+
+Performance policy should live in one controller. It can lower frame rate, disable bloom, disable oscilloscope, or skip spatial repulsion when frame time or battery status requires it.
+
+## Suggested migration order
+
+1. Load `face3d_engine.js` next to `face.js`.
+2. Use `MasterFace3D.VisemeDriver` for duration-based lipsync while keeping the existing renderer.
+3. Replace direct mouth zone mutation with blendshape-driven mouth targets.
+4. Convert existing mask builders to normalized anchors one mask at a time.
+5. Move particle storage from objects to typed arrays.
+6. Add spatial hash repulsion for high-density zones.
+7. Add an optional WebGL renderer while preserving the retro canvas renderer as default.
+
+## Live integration sketch
+
+```js
+import { Face3DEngine } from '/face3d_engine.js';
+
+const engine = new Face3DEngine();
+engine.setEmotion({ focus: 0.4, confidence: 0.8 });
+engine.setPose({ yaw: 0.15, pitch: -0.04 });
+engine.tick(dt);
+const frame = engine.snapshot();
+```
+
+The current `face.js` can consume `snapshot()` data gradually without losing the existing visual identity.

--- a/MASTER/docs/face3d_engine.md
+++ b/MASTER/docs/face3d_engine.md
@@ -10,6 +10,7 @@ This document describes the incremental path from the current retro canvas face 
 - Keep particles semantically assigned to anatomical zones.
 - Use typed arrays in hot loops.
 - Make speech, mood, confidence, tool events, and verdicts drive one coherent face state.
+- Mine existing visual clusters and route them into one shared emotion/topology system.
 
 ## New modules
 
@@ -19,7 +20,100 @@ This document describes the incremental path from the current retro canvas face 
 
 `web/public/face3d_preview.js` is an optional boot module. It only runs when the page URL includes `?face3d=1`, so it can be used as a safe preview path before replacing the live `face.js` renderer.
 
+`web/public/cluster_miner.js` listens to `master:visual`, `master:codebase`, and `master:rule_event`, groups them into semantic clusters, emits `master:clusters`, and can feed `Face3DPreview.engine.setEmotion(...)` when the preview is active.
+
+`data/visual_clusters.yml` is the canonical registry for current and proposed visual/cognition clusters.
+
 The modules are intentionally additive. They do not replace `face.js` yet.
+
+## Mined clusters
+
+### Face Particle Body
+
+Files:
+
+- `web/public/face.js`
+- `web/public/face3d_engine.js`
+- `web/public/face3d_renderer.js`
+- `web/public/face3d_preview.js`
+
+Purpose: embody the assistant as a semantic particle face. The current renderer supplies the retro soul; Face3D supplies normalized topology, blendshapes, typed arrays, and preview rendering.
+
+### Cognition Ecology
+
+Files:
+
+- `web/public/cognition_ecology.js`
+
+Purpose: render runtime cognition as terrain, weather, trails, memories, and agent spirits.
+
+### Codebase Topology
+
+Files:
+
+- `web/public/codebase.js`
+- `data/architectures.yml`
+
+Purpose: render modules as particle clusters. Violations agitate clusters; fixes settle them. This corresponds to Architecture #15.
+
+### Runtime Visual Bridge
+
+Files:
+
+- `web/public/visual_bridge.js`
+
+Purpose: normalize runtime events into `master:visual` state: mode, topology, entropy, confidence, provider.
+
+### Speech and Audio Body
+
+Files:
+
+- `lib/voice/speech.rb`
+- `bin/tts-worker`
+- `web/public/face.js`
+
+Purpose: convert streamed response text into speech, analyse decoded audio, and reshape the mouth during playback.
+
+### Repo Ecology
+
+Files:
+
+- `docs/repo_ecology.md`
+- `data/visual_clusters.yml`
+
+Purpose: promote the repository from a bag of files into semantic topology, dependency ecology, cognitive geography, architectural history, and organizational memory.
+
+## New proposed clusters
+
+### Cluster Miner
+
+Runtime/browser cluster miner that groups live visual events into reusable cluster states with heat, confidence, and evidence.
+
+### Evidence Graph
+
+Tracks why a file or event belongs to a cluster: imports, runtime event coupling, shared vocabulary, shared data files, changed-together history, or explicit docs.
+
+### Emotion Bus
+
+Converts visual entropy/confidence/mode/provider and cluster heat into a single shared emotion vector:
+
+```js
+{
+  arousal,
+  valence,
+  focus,
+  confidence,
+  fatigue
+}
+```
+
+### Topology Registry
+
+Canonical registry for `papua-mask`, `serpent`, `neural`, `torus`, `sphere`, `codebase`, and future terrain/body forms.
+
+### Migration Radar
+
+Ranks safe migration steps by touched files, blast radius, rollback plan, and confidence.
 
 ## Core concepts
 
@@ -97,14 +191,16 @@ Performance policy should live in one controller. It can lower frame rate, disab
 
 ## Suggested migration order
 
-1. Load `face3d_engine.js`, `face3d_renderer.js`, and `face3d_preview.js` next to `face.js`.
+1. Load `face3d_engine.js`, `face3d_renderer.js`, `face3d_preview.js`, and `cluster_miner.js` next to `face.js`.
 2. Verify the preview with `?face3d=1`.
-3. Use `MasterFace3D.VisemeDriver` for duration-based lipsync while keeping the existing renderer.
-4. Replace direct mouth zone mutation with blendshape-driven mouth targets.
-5. Convert existing mask builders to normalized anchors one mask at a time.
-6. Move particle storage from objects to typed arrays.
-7. Add spatial hash repulsion for high-density zones.
-8. Add an optional WebGL renderer while preserving the retro canvas renderer as default.
+3. Use `MASTERClusterMiner.snapshot()` to inspect mined runtime clusters.
+4. Route `master:clusters` into Face3D emotion state.
+5. Use `MasterFace3D.VisemeDriver` for duration-based lipsync while keeping the existing renderer.
+6. Replace direct mouth zone mutation with blendshape-driven mouth targets.
+7. Convert existing mask builders to normalized anchors one mask at a time.
+8. Move particle storage from objects to typed arrays.
+9. Add spatial hash repulsion for high-density zones.
+10. Add an optional WebGL renderer while preserving the retro canvas renderer as default.
 
 ## Preview integration
 
@@ -114,6 +210,7 @@ Add these after the existing `face.js` script:
 <script type="module" src="/face3d_engine.js"></script>
 <script type="module" src="/face3d_renderer.js"></script>
 <script type="module" src="/face3d_preview.js"></script>
+<script src="/cluster_miner.js" defer></script>
 ```
 
 Then open the chat UI with:
@@ -133,7 +230,10 @@ import { Face3DCanvasRenderer } from '/face3d_renderer.js';
 const engine = new Face3DEngine();
 const renderer = new Face3DCanvasRenderer(document.getElementById('face'));
 
-engine.setEmotion({ focus: 0.4, confidence: 0.8 });
+window.addEventListener('master:clusters', event => {
+  engine.setEmotion(event.detail.emotion);
+});
+
 engine.setPose({ yaw: 0.15, pitch: -0.04 });
 engine.tick(dt);
 renderer.draw(engine.snapshot());

--- a/MASTER/docs/face3d_engine.md
+++ b/MASTER/docs/face3d_engine.md
@@ -11,11 +11,15 @@ This document describes the incremental path from the current retro canvas face 
 - Use typed arrays in hot loops.
 - Make speech, mood, confidence, tool events, and verdicts drive one coherent face state.
 
-## New module
+## New modules
 
 `web/public/face3d_engine.js` adds a standalone engine namespace at `window.MasterFace3D` and exports the same API as an ES module.
 
-The module is intentionally additive. It does not replace `face.js` yet.
+`web/public/face3d_renderer.js` adds a `Face3DCanvasRenderer` adapter that can render the engine snapshot back through a retro low-resolution phosphor/dither canvas path.
+
+`web/public/face3d_preview.js` is an optional boot module. It only runs when the page URL includes `?face3d=1`, so it can be used as a safe preview path before replacing the live `face.js` renderer.
+
+The modules are intentionally additive. They do not replace `face.js` yet.
 
 ## Core concepts
 
@@ -70,30 +74,69 @@ High-level events should update one emotion vector:
 
 Blendshapes are derived from this vector, so the face feels continuous rather than event-random.
 
+### Renderer adapter
+
+The renderer consumes the engine snapshot:
+
+```js
+{
+  count,
+  x,
+  y,
+  depth,
+  brightness,
+  zone
+}
+```
+
+It accumulates particles into a low-resolution float buffer, applies phosphor decay, runs Atkinson or Bayer dithering, tints pixels by semantic zone, and blits the result to the face canvas.
+
 ### Quality controller
 
 Performance policy should live in one controller. It can lower frame rate, disable bloom, disable oscilloscope, or skip spatial repulsion when frame time or battery status requires it.
 
 ## Suggested migration order
 
-1. Load `face3d_engine.js` next to `face.js`.
-2. Use `MasterFace3D.VisemeDriver` for duration-based lipsync while keeping the existing renderer.
-3. Replace direct mouth zone mutation with blendshape-driven mouth targets.
-4. Convert existing mask builders to normalized anchors one mask at a time.
-5. Move particle storage from objects to typed arrays.
-6. Add spatial hash repulsion for high-density zones.
-7. Add an optional WebGL renderer while preserving the retro canvas renderer as default.
+1. Load `face3d_engine.js`, `face3d_renderer.js`, and `face3d_preview.js` next to `face.js`.
+2. Verify the preview with `?face3d=1`.
+3. Use `MasterFace3D.VisemeDriver` for duration-based lipsync while keeping the existing renderer.
+4. Replace direct mouth zone mutation with blendshape-driven mouth targets.
+5. Convert existing mask builders to normalized anchors one mask at a time.
+6. Move particle storage from objects to typed arrays.
+7. Add spatial hash repulsion for high-density zones.
+8. Add an optional WebGL renderer while preserving the retro canvas renderer as default.
+
+## Preview integration
+
+Add these after the existing `face.js` script:
+
+```html
+<script type="module" src="/face3d_engine.js"></script>
+<script type="module" src="/face3d_renderer.js"></script>
+<script type="module" src="/face3d_preview.js"></script>
+```
+
+Then open the chat UI with:
+
+```text
+?face3d=1
+```
+
+`face3d_preview.js` will take over the existing `#face` canvas only in that mode.
 
 ## Live integration sketch
 
 ```js
 import { Face3DEngine } from '/face3d_engine.js';
+import { Face3DCanvasRenderer } from '/face3d_renderer.js';
 
 const engine = new Face3DEngine();
+const renderer = new Face3DCanvasRenderer(document.getElementById('face'));
+
 engine.setEmotion({ focus: 0.4, confidence: 0.8 });
 engine.setPose({ yaw: 0.15, pitch: -0.04 });
 engine.tick(dt);
-const frame = engine.snapshot();
+renderer.draw(engine.snapshot());
 ```
 
 The current `face.js` can consume `snapshot()` data gradually without losing the existing visual identity.

--- a/MASTER/lib/voice/speech.rb
+++ b/MASTER/lib/voice/speech.rb
@@ -11,6 +11,8 @@ module Master
     EDGE_TTS = File.executable?(WORKER)
     ESPEAK   = %w[/usr/bin/espeak /usr/local/bin/espeak].find { |p| File.executable?(p) }
 
+    Audio = Struct.new(:bytes, :mime_type, keyword_init: true)
+
     VOICES = {
       osman:   "ms-MY-OsmanNeural",
       yasmin:  "ms-MY-YasminNeural",
@@ -54,32 +56,41 @@ module Master
     module_function
 
     def available?
-      !EDGE_TTS.nil? || !ESPEAK.nil?
+      EDGE_TTS || !ESPEAK.nil?
     end
 
     def synthesize(text, voice: DEFAULT_VOICE, style: DEFAULT_STYLE)
       text_str = text.to_s.strip
       return if text_str.empty?
+      return unless available?
 
       style = infer_style(text, fallback: DEFAULT_STYLE) if style == :auto
       style = DEFAULT_STYLE unless STYLES.key?(style)
       voice = DEFAULT_VOICE unless VOICES.key?(voice)
 
       if EDGE_TTS
-        synthesize_edge(text, voice: voice, style: style)
-      elsif ESPEAK
-        synthesize_espeak(text)
+        path = synthesize_edge(text_str, voice: voice, style: style)
+        return path if path
       end
+
+      synthesize_espeak(text_str) if ESPEAK
+    end
+
+    def synthesize_audio(text, **opts)
+      path = synthesize(text, **opts)
+      return unless path
+
+      Audio.new(bytes: File.binread(path), mime_type: mime_type_for(path))
+    ensure
+      File.unlink(path) rescue nil if path
     end
 
     def synthesize_bytes(text, **opts)
-      path = synthesize(text, **opts)
-      return unless path
-      begin
-        File.binread(path)
-      ensure
-        File.unlink(path) rescue nil
-      end
+      synthesize_audio(text, **opts)&.bytes
+    end
+
+    def mime_type_for(path)
+      File.extname(path.to_s).downcase == ".wav" ? "audio/wav" : "audio/mpeg"
     end
 
     # Shells out to exe/tts-worker — Falcon's Async scheduler blocks Process.fork

--- a/MASTER/test/test_speech.rb
+++ b/MASTER/test/test_speech.rb
@@ -3,7 +3,6 @@
 require_relative "test_helper"
 
 class TestSpeech < Minitest::Test
-  # module interface
   def test_available_returns_boolean
     assert_includes [true, false], Master::Voice::Speech.available?
   end
@@ -27,39 +26,10 @@ class TestSpeech < Minitest::Test
     assert_nil Master::Voice::Speech.synthesize_bytes("")
   end
 
-  # when edge-tts unavailable
-  def test_synthesize_returns_nil_when_unavailable
-    # Stub Speech.available? to false
-    Master::Voice::Speech.stub(:available?, false) do
-      assert_nil Master::Voice::Speech.synthesize("hello")
-    end
-  end
-
-  def test_synthesize_bytes_returns_nil_when_unavailable
-    Master::Voice::Speech.stub(:available?, false) do
-      assert_nil Master::Voice::Speech.synthesize_bytes("hello")
-    end
-  end
-
-  # when edge-tts available (mock system call)
-  def test_synthesize_calls_edge_tts_with_correct_args
-    skip "edge-tts not installed" unless Master::Voice::Speech.available?
-
-    tmp = nil
-    Master::Voice::Speech.stub(:synthesize, ->(text, **) {
-      # Just verify we can call it without raising
-      nil
-    }) do
-      tmp = Master::Voice::Speech.synthesize("test", voice: :osman, style: :deep)
-    end
-    assert_nil tmp  # mock returns nil
-  end
-
   def test_synthesize_bytes_cleans_up_temp_file
     fake_path = "/tmp/m3_tts_test_fake.mp3"
 
     Master::Voice::Speech.stub(:synthesize, fake_path) do
-      # Create a fake mp3
       File.write(fake_path, "fake-mp3-data")
       bytes = Master::Voice::Speech.synthesize_bytes("hello")
       assert_equal "fake-mp3-data", bytes
@@ -67,10 +37,7 @@ class TestSpeech < Minitest::Test
     end
   end
 
-  # voice / style lookup
   def test_unknown_voice_falls_back_to_default
-    # Speech.synthesize uses VOICES.fetch(voice, VOICES[DEFAULT_VOICE])
-    # so unknown symbol falls back to Osman
     default_voice = Master::Voice::Speech::VOICES[Master::Voice::Speech::DEFAULT_VOICE]
     assert default_voice
   end

--- a/MASTER/test/test_speech.rb
+++ b/MASTER/test/test_speech.rb
@@ -26,6 +26,30 @@ class TestSpeech < Minitest::Test
     assert_nil Master::Voice::Speech.synthesize_bytes("")
   end
 
+  def test_synthesize_audio_returns_mpeg_for_mp3
+    fake_path = "/tmp/m3_tts_test_fake.mp3"
+
+    Master::Voice::Speech.stub(:synthesize, fake_path) do
+      File.write(fake_path, "fake-mp3-data")
+      audio = Master::Voice::Speech.synthesize_audio("hello")
+      assert_equal "fake-mp3-data", audio.bytes
+      assert_equal "audio/mpeg", audio.mime_type
+      refute File.exist?(fake_path), "temp file should be deleted"
+    end
+  end
+
+  def test_synthesize_audio_returns_wav_for_espeak_fallback
+    fake_path = "/tmp/m3_tts_test_fake.wav"
+
+    Master::Voice::Speech.stub(:synthesize, fake_path) do
+      File.write(fake_path, "fake-wav-data")
+      audio = Master::Voice::Speech.synthesize_audio("hello")
+      assert_equal "fake-wav-data", audio.bytes
+      assert_equal "audio/wav", audio.mime_type
+      refute File.exist?(fake_path), "temp file should be deleted"
+    end
+  end
+
   def test_synthesize_bytes_cleans_up_temp_file
     fake_path = "/tmp/m3_tts_test_fake.mp3"
 

--- a/MASTER/web/app/controllers/chat_controller.rb
+++ b/MASTER/web/app/controllers/chat_controller.rb
@@ -181,9 +181,9 @@ class ChatController < ApplicationController
     # :auto opts in to per-clause infer_style. Otherwise enforce whitelist.
     style = Master::Voice::Speech::DEFAULT_STYLE if style != :auto && !Master::Voice::Speech::STYLES.key?(style)
 
-    bytes = Master::Voice::Speech.synthesize_bytes(text, voice: voice, style: style)
-    if bytes && bytes.bytesize > 0
-      send_data bytes, type: "audio/mpeg", disposition: "inline"
+    audio = Master::Voice::Speech.synthesize_audio(text, voice: voice, style: style)
+    if audio&.bytes && audio.bytes.bytesize.positive?
+      send_data audio.bytes, type: audio.mime_type, disposition: "inline"
     else
       head :service_unavailable
     end

--- a/MASTER/web/public/cluster_miner.js
+++ b/MASTER/web/public/cluster_miner.js
@@ -1,0 +1,184 @@
+"use strict";
+
+// Browser-side cluster miner bridge.
+// This does not scan the repository directly. It observes live visual events and
+// groups them into reusable cluster signals that other renderers can consume.
+
+(() => {
+  const CLUSTERS = Object.freeze({
+    face_particle_body: {
+      match: /mood|model|verdict|confidence|tool|tts|speech|stt|gesture|face/i,
+      layer: "embodiment",
+      emotion: { arousal: 0.35, focus: 0.25 }
+    },
+    cognition_ecology: {
+      match: /memory|retriev|context|compact|entropy|provider|visual|ecology/i,
+      layer: "background_world",
+      emotion: { arousal: 0.22, focus: 0.18 }
+    },
+    codebase_topology: {
+      match: /codebase|rule_loop|super_loop|violation|clean|converged|topology/i,
+      layer: "repository_body",
+      emotion: { arousal: 0.32, focus: 0.45 }
+    },
+    speech_audio_body: {
+      match: /speak|speech|tts|voice|audio|viseme|sentence/i,
+      layer: "voice",
+      emotion: { arousal: 0.30, focus: 0.18, valence: 0.10 }
+    },
+    repo_ecology: {
+      match: /scan|classify|cluster|score|simulate|critique|apply|rollback/i,
+      layer: "repository_mining",
+      emotion: { arousal: 0.28, focus: 0.38 }
+    }
+  });
+
+  const state = {
+    clusters: new Map(),
+    evidence: [],
+    lastEmissionAt: 0
+  };
+
+  function now() {
+    return performance.now();
+  }
+
+  function clamp(v, lo = 0, hi = 1) {
+    return Math.max(lo, Math.min(hi, Number(v)));
+  }
+
+  function ensureCluster(id, spec) {
+    if (!state.clusters.has(id)) {
+      state.clusters.set(id, {
+        id,
+        layer: spec.layer,
+        heat: 0,
+        confidence: 0.5,
+        evidence: [],
+        lastSeenAt: 0,
+        count: 0
+      });
+    }
+    return state.clusters.get(id);
+  }
+
+  function classify(detail = {}) {
+    const text = `${detail.name || ""} ${detail.mode || ""} ${detail.topology || ""} ${detail.provider || ""} ${JSON.stringify(detail.raw || {})}`;
+    const found = [];
+    for (const [id, spec] of Object.entries(CLUSTERS)) {
+      if (!spec.match.test(text)) continue;
+      found.push({ id, spec });
+    }
+    if (!found.length) found.push({ id: "cognition_ecology", spec: CLUSTERS.cognition_ecology });
+    return found;
+  }
+
+  function ingest(detail = {}) {
+    const t = now();
+    const matches = classify(detail);
+    const entropy = clamp(detail.entropy ?? 0.24);
+    const confidence = clamp(detail.confidence ?? 0.68);
+    const evidence = {
+      at: t,
+      name: detail.name || "event",
+      mode: detail.mode || "event",
+      topology: detail.topology || "unknown",
+      provider: detail.provider || "unknown",
+      entropy,
+      confidence
+    };
+
+    for (const { id, spec } of matches) {
+      const cluster = ensureCluster(id, spec);
+      cluster.heat = clamp(cluster.heat + 0.18 + entropy * 0.28);
+      cluster.confidence = clamp((cluster.confidence * 0.75) + (confidence * 0.25));
+      cluster.lastSeenAt = t;
+      cluster.count += 1;
+      cluster.evidence.push(evidence);
+      if (cluster.evidence.length > 12) cluster.evidence.shift();
+    }
+
+    state.evidence.push(evidence);
+    if (state.evidence.length > 80) state.evidence.shift();
+    emitClusterState();
+  }
+
+  function tick() {
+    const t = now();
+    for (const cluster of state.clusters.values()) {
+      const age = Math.max(0, t - cluster.lastSeenAt);
+      const decay = age > 1200 ? 0.985 : 0.995;
+      cluster.heat *= decay;
+      if (cluster.heat < 0.002) cluster.heat = 0;
+    }
+    if (t - state.lastEmissionAt > 1000) emitClusterState();
+    requestAnimationFrame(tick);
+  }
+
+  function emotionFromClusters() {
+    let arousal = 0;
+    let focus = 0;
+    let valence = 0;
+    let confidence = 0;
+    let heatTotal = 0;
+
+    for (const [id, cluster] of state.clusters) {
+      const spec = CLUSTERS[id] || {};
+      const heat = cluster.heat;
+      const e = spec.emotion || {};
+      arousal += (e.arousal || 0) * heat;
+      focus += (e.focus || 0) * heat;
+      valence += (e.valence || 0) * heat;
+      confidence += cluster.confidence * heat;
+      heatTotal += heat;
+    }
+
+    if (heatTotal <= 0) return { arousal: 0, valence: 0, focus: 0, confidence: 0.88, fatigue: 0 };
+    return {
+      arousal: clamp(arousal / heatTotal + heatTotal * 0.08),
+      valence: clamp(valence / heatTotal, -1, 1),
+      focus: clamp(focus / heatTotal + heatTotal * 0.05),
+      confidence: clamp(confidence / heatTotal),
+      fatigue: clamp(Math.max(0, heatTotal - 2.0) * 0.12)
+    };
+  }
+
+  function snapshot() {
+    return {
+      clusters: [...state.clusters.values()].map(cluster => ({
+        id: cluster.id,
+        layer: cluster.layer,
+        heat: Number(cluster.heat.toFixed(3)),
+        confidence: Number(cluster.confidence.toFixed(3)),
+        count: cluster.count,
+        evidence: cluster.evidence.slice(-4)
+      })),
+      emotion: emotionFromClusters(),
+      evidence: state.evidence.slice(-8)
+    };
+  }
+
+  function emitClusterState() {
+    state.lastEmissionAt = now();
+    const detail = snapshot();
+    window.dispatchEvent(new CustomEvent("master:clusters", { detail }));
+
+    if (window.Face3DPreview?.engine && detail.emotion) {
+      window.Face3DPreview.engine.setEmotion(detail.emotion);
+    }
+  }
+
+  window.addEventListener("master:visual", event => ingest(event.detail || {}));
+  window.addEventListener("master:codebase", event => ingest({ ...(event.detail || {}), name: "codebase:topology", topology: "codebase" }));
+  window.addEventListener("master:rule_event", event => ingest({ ...(event.detail || {}), name: event.detail?.status ? `rule_loop:${event.detail.status}` : "rule_loop:event", topology: "codebase" }));
+
+  window.MASTERClusterMiner = Object.freeze({
+    state,
+    classify,
+    ingest,
+    snapshot,
+    emotion: emotionFromClusters
+  });
+
+  requestAnimationFrame(tick);
+})();

--- a/MASTER/web/public/face3d_engine.js
+++ b/MASTER/web/public/face3d_engine.js
@@ -1,0 +1,605 @@
+"use strict";
+
+// MASTER Face3D Engine
+// A small, standalone engine for semantic 3D faces rendered as particles.
+// It does not replace the retro face.js renderer yet; it exposes the normalized
+// topology, blendshape rig, typed-array particle core, spatial hash, and quality
+// controller needed to migrate face.js in small safe steps.
+
+const ZONES = Object.freeze({
+  outlineL: 1, outlineR: 2,
+  eyeL: 3, eyeR: 4, pupilL: 5, pupilR: 6,
+  browL: 7, browR: 8,
+  noseRidge: 9, noseFlare: 10,
+  mouth: 11, chin: 12,
+  crown: 13, cheekL: 14, cheekR: 15,
+  sideL: 16, sideR: 17
+});
+
+const ZONE_NAMES = Object.freeze(Object.fromEntries(
+  Object.entries(ZONES).map(([name, id]) => [id, name])
+));
+
+const DEFAULT_BLEND = Object.freeze({
+  blink: 0,
+  squint: 0,
+  browInnerUp: 0,
+  browDown: 0,
+  smile: 0,
+  frown: 0,
+  jawOpen: 0,
+  mouthWide: 0,
+  mouthRound: 0,
+  pupilDilate: 0,
+  nostrilFlare: 0,
+  cheekRaise: 0,
+  shock: 0,
+  chibi: 0
+});
+
+const DEFAULT_EMOTION = Object.freeze({
+  arousal: 0,
+  valence: 0,
+  focus: 0,
+  confidence: 1,
+  fatigue: 0
+});
+
+function clamp(v, lo = 0, hi = 1) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function damp(current, target, lambda, dtMs) {
+  const t = 1 - Math.exp(-lambda * dtMs * 0.001);
+  return lerp(current, target, t);
+}
+
+function zoneId(zone) {
+  return ZONES[zone] || 0;
+}
+
+function makeAnchor(x, y, z, zone, u = 0, normal = [0, 0, 1]) {
+  return { x, y, z, zone, zoneId: zoneId(zone), u, normal };
+}
+
+function line3(x0, y0, z0, x1, y1, z1, n, zone) {
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const t = n > 1 ? i / (n - 1) : 0;
+    out.push(makeAnchor(lerp(x0, x1, t), lerp(y0, y1, t), lerp(z0, z1, t), zone, t));
+  }
+  return out;
+}
+
+function ring3(cx, cy, cz, rx, ry, n, zone, zWave = 0) {
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const t = i / n;
+    const a = t * Math.PI * 2;
+    const x = cx + Math.cos(a) * rx;
+    const y = cy + Math.sin(a) * ry;
+    const z = cz + Math.sin(a * 2) * zWave;
+    out.push(makeAnchor(x, y, z, zone, t, normalize3([x - cx, y - cy, 0.7])));
+  }
+  return out;
+}
+
+function disc3(cx, cy, cz, r, n, zone) {
+  const out = [];
+  const golden = Math.PI * (3 - Math.sqrt(5));
+  for (let i = 0; i < n; i++) {
+    const t = (i + 0.5) / n;
+    const rr = r * Math.sqrt(t);
+    const a = i * golden;
+    out.push(makeAnchor(cx + Math.cos(a) * rr, cy + Math.sin(a) * rr, cz, zone, t));
+  }
+  return out;
+}
+
+function normalize3(v) {
+  const len = Math.hypot(v[0], v[1], v[2]) || 1;
+  return [v[0] / len, v[1] / len, v[2] / len];
+}
+
+function buildCanonicalMask(kind = "sepik") {
+  switch (kind) {
+    case "asmat": return buildAsmatMask();
+    case "baining": return buildBainingMask();
+    case "tolai": return buildTolaiMask();
+    case "neutral": return buildNeutralMask();
+    default: return buildSepikMask();
+  }
+}
+
+function zoneMap(anchors) {
+  const zones = {};
+  for (const a of anchors) {
+    if (!zones[a.zone]) zones[a.zone] = [];
+    zones[a.zone].push(a);
+  }
+  return { anchors, zones };
+}
+
+function buildNeutralMask() {
+  const a = [];
+  for (let i = 0; i < 72; i++) {
+    const t = i / 71;
+    const y = -0.92 + t * 1.84;
+    const w = 0.18 + 0.54 * Math.sin(t * Math.PI);
+    const z = 0.08 * Math.sin(t * Math.PI);
+    a.push(makeAnchor(-w, y, z, "outlineL", t));
+    a.push(makeAnchor(w, y, z, "outlineR", t));
+  }
+  a.push(...line3(-0.42, -0.30, 0.22, -0.12, -0.24, 0.34, 16, "browL"));
+  a.push(...line3(0.12, -0.24, 0.34, 0.42, -0.30, 0.22, 16, "browR"));
+  a.push(...ring3(-0.28, -0.13, 0.42, 0.13, 0.07, 28, "eyeL", 0.015));
+  a.push(...ring3(0.28, -0.13, 0.42, 0.13, 0.07, 28, "eyeR", 0.015));
+  a.push(...disc3(-0.28, -0.13, 0.49, 0.035, 8, "pupilL"));
+  a.push(...disc3(0.28, -0.13, 0.49, 0.035, 8, "pupilR"));
+  a.push(...line3(0, -0.34, 0.46, 0, 0.34, 0.58, 30, "noseRidge"));
+  a.push(...ring3(-0.07, 0.39, 0.54, 0.045, 0.025, 8, "noseFlare"));
+  a.push(...ring3(0.07, 0.39, 0.54, 0.045, 0.025, 8, "noseFlare"));
+  a.push(...mouthAnchors("neutral", 34));
+  a.push(...line3(-0.14, 0.80, 0.18, 0.14, 0.80, 0.18, 12, "chin"));
+  a.push(...disc3(-0.38, 0.22, 0.26, 0.055, 10, "cheekL"));
+  a.push(...disc3(0.38, 0.22, 0.26, 0.055, 10, "cheekR"));
+  return zoneMap(a);
+}
+
+function buildSepikMask() {
+  const base = buildNeutralMask().anchors.slice();
+  const crown = [];
+  for (let i = 0; i < 16; i++) {
+    const t = (i - 7.5) / 7.5;
+    crown.push(...line3(t * 0.09, -0.78, 0.18, t * 0.28, -1.28 - Math.abs(t) * 0.16, 0.05, 9, "crown"));
+  }
+  const noseHook = line3(0, 0.28, 0.58, 0.15, 0.44, 0.54, 8, "noseRidge");
+  return zoneMap(base.concat(crown, noseHook));
+}
+
+function buildAsmatMask() {
+  const a = buildNeutralMask().anchors.filter(anchor => !anchor.zone.startsWith("eye"));
+  a.push(...diamondEye(-0.29, -0.08, 0.43, "eyeL"));
+  a.push(...diamondEye(0.29, -0.08, 0.43, "eyeR"));
+  a.push(...disc3(-0.29, -0.08, 0.50, 0.040, 8, "pupilL"));
+  a.push(...disc3(0.29, -0.08, 0.50, 0.040, 8, "pupilR"));
+  for (let r = 0; r < 3; r++) {
+    const y = -0.58 - r * 0.12;
+    a.push(...line3(-0.34, y, 0.14, 0, y - 0.08, 0.20, 8, "crown"));
+    a.push(...line3(0, y - 0.08, 0.20, 0.34, y, 0.14, 8, "crown"));
+  }
+  return zoneMap(a);
+}
+
+function buildBainingMask() {
+  const a = buildNeutralMask().anchors.filter(anchor => !["eyeL", "eyeR", "pupilL", "pupilR", "mouth"].includes(anchor.zone));
+  a.push(...ring3(-0.36, -0.18, 0.40, 0.22, 0.18, 36, "eyeL", 0.02));
+  a.push(...ring3(0.36, -0.18, 0.40, 0.22, 0.18, 36, "eyeR", 0.02));
+  a.push(...spiralEye(-0.36, -0.18, 0.51, "pupilL"));
+  a.push(...spiralEye(0.36, -0.18, 0.51, "pupilR"));
+  a.push(...ring3(0, 0.48, 0.42, 0.38, 0.16, 40, "mouth", 0.02));
+  return zoneMap(a);
+}
+
+function buildTolaiMask() {
+  const a = buildNeutralMask().anchors.filter(anchor => !["outlineL", "outlineR", "mouth"].includes(anchor.zone));
+  for (let i = 0; i < 56; i++) {
+    const t = i / 55;
+    const y = -1.05 + t * 1.95;
+    const w = 0.12 + t * 0.60;
+    a.push(makeAnchor(-w, y, 0.02, "outlineL", t));
+    a.push(makeAnchor(w, y, 0.02, "outlineR", t));
+  }
+  a.push(...mouthAnchors("O", 32));
+  a.push(...line3(-0.72, -0.05, 0.00, -0.84, 0.66, -0.05, 16, "sideL"));
+  a.push(...line3(0.72, -0.05, 0.00, 0.84, 0.66, -0.05, 16, "sideR"));
+  return zoneMap(a);
+}
+
+function diamondEye(cx, cy, cz, zone) {
+  return [
+    ...line3(cx, cy - 0.10, cz, cx + 0.18, cy, cz, 8, zone),
+    ...line3(cx + 0.18, cy, cz, cx, cy + 0.10, cz, 8, zone),
+    ...line3(cx, cy + 0.10, cz, cx - 0.18, cy, cz, 8, zone),
+    ...line3(cx - 0.18, cy, cz, cx, cy - 0.10, cz, 8, zone)
+  ];
+}
+
+function spiralEye(cx, cy, cz, zone) {
+  const out = [];
+  for (let i = 0; i < 26; i++) {
+    const t = i / 25;
+    const ang = t * Math.PI * 4;
+    const r = t * 0.15;
+    out.push(makeAnchor(cx + Math.cos(ang) * r, cy + Math.sin(ang) * r * 0.82, cz, zone, t));
+  }
+  return out;
+}
+
+function mouthAnchors(shape = "neutral", n = 34) {
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const t = n > 1 ? i / (n - 1) : 0;
+    const u = (t - 0.5) * 2;
+    const x = u * 0.34;
+    let y = 0.58;
+    let z = 0.42;
+    if (shape === "smile") y -= Math.sin(t * Math.PI) * 0.12;
+    if (shape === "frown") y += Math.sin(t * Math.PI) * 0.12;
+    if (shape === "O") { y += Math.sin(t * Math.PI) * 0.18; z += 0.04; }
+    out.push(makeAnchor(x, y, z, "mouth", t));
+  }
+  return out;
+}
+
+function applyBlendshape(anchor, blend) {
+  let x = anchor.x;
+  let y = anchor.y;
+  let z = anchor.z;
+  const zone = anchor.zone;
+  const side = x < 0 ? -1 : 1;
+  const centerWeight = 1 - clamp(Math.abs(x) / 0.7);
+
+  if (zone === "browL" || zone === "browR") {
+    y += blend.browDown * 0.07;
+    y -= blend.browInnerUp * centerWeight * 0.10;
+    z += blend.focus * 0.02 || 0;
+  }
+
+  if (zone === "eyeL" || zone === "eyeR") {
+    y *= 1 - blend.blink * 0.72 - blend.squint * 0.20;
+    x += side * blend.shock * 0.035;
+  }
+
+  if (zone === "pupilL" || zone === "pupilR") {
+    x += side * blend.shock * 0.025;
+    y -= blend.shock * 0.010;
+    z += blend.pupilDilate * 0.030;
+  }
+
+  if (zone === "mouth") {
+    const lower = anchor.u > 0.50 ? 1 : 0.45;
+    y += blend.jawOpen * lower * 0.16;
+    y -= blend.smile * Math.sin(anchor.u * Math.PI) * 0.11;
+    y += blend.frown * Math.sin(anchor.u * Math.PI) * 0.10;
+    x *= 1 + blend.mouthWide * 0.22 - blend.mouthRound * 0.22;
+    z += blend.mouthRound * 0.08;
+  }
+
+  if (zone === "noseFlare") {
+    x += side * blend.nostrilFlare * 0.035;
+    z += blend.nostrilFlare * 0.035;
+  }
+
+  if (zone === "cheekL" || zone === "cheekR") {
+    y -= blend.cheekRaise * 0.07;
+    z += blend.cheekRaise * 0.04;
+  }
+
+  if (blend.chibi > 0) {
+    y *= 1 - blend.chibi * 0.28;
+    x *= 1 + blend.chibi * 0.10;
+  }
+
+  return { ...anchor, x, y, z };
+}
+
+function deriveBlendFromEmotion(emotion, previous = DEFAULT_BLEND) {
+  const e = { ...DEFAULT_EMOTION, ...emotion };
+  return {
+    ...previous,
+    browDown: clamp(e.focus * 0.45 + (1 - e.confidence) * 0.35 + Math.max(0, -e.valence) * 0.20),
+    browInnerUp: clamp((1 - e.confidence) * 0.25 + Math.max(0, e.valence) * 0.20),
+    pupilDilate: clamp(e.arousal * 0.55 + (1 - e.confidence) * 0.18),
+    smile: clamp(Math.max(0, e.valence) * 0.55),
+    frown: clamp(Math.max(0, -e.valence) * 0.45),
+    squint: clamp(e.focus * 0.18 + e.fatigue * 0.20),
+    cheekRaise: clamp(Math.max(0, e.valence) * 0.30)
+  };
+}
+
+class ParticleField3D {
+  constructor(count = 2200) {
+    this.count = count;
+    this.x = new Float32Array(count);
+    this.y = new Float32Array(count);
+    this.z = new Float32Array(count);
+    this.vx = new Float32Array(count);
+    this.vy = new Float32Array(count);
+    this.homeX = new Float32Array(count);
+    this.homeY = new Float32Array(count);
+    this.homeZ = new Float32Array(count);
+    this.u = new Float32Array(count);
+    this.mass = new Float32Array(count);
+    this.zone = new Uint8Array(count);
+    this.seed = new Uint32Array(count);
+    this.depth = new Float32Array(count);
+    this.brightness = new Float32Array(count);
+
+    for (let i = 0; i < count; i++) {
+      this.x[i] = (Math.random() - 0.5) * 2;
+      this.y[i] = (Math.random() - 0.5) * 2;
+      this.z[i] = 0;
+      this.mass[i] = 0.75 + Math.random() * 0.75;
+      this.u[i] = Math.random();
+      this.seed[i] = (Math.random() * 0xFFFFFFFF) >>> 0;
+    }
+  }
+
+  assignStable(topology) {
+    const zoneNames = Object.keys(topology.zones);
+    const weighted = [];
+    const density = { pupilL: 5, pupilR: 5, eyeL: 3, eyeR: 3, mouth: 2, noseRidge: 2, browL: 2, browR: 2 };
+    for (const name of zoneNames) {
+      const repeats = density[name] || 1;
+      for (let r = 0; r < repeats; r++) weighted.push(name);
+    }
+
+    for (let i = 0; i < this.count; i++) {
+      const name = weighted[i % weighted.length];
+      const list = topology.zones[name] || topology.anchors;
+      const u = ((this.seed[i] % 10000) / 9999);
+      const idx = Math.min(list.length - 1, Math.floor(u * list.length));
+      const a = list[idx];
+      this.zone[i] = a.zoneId;
+      this.u[i] = u;
+      this.setHome(i, a);
+    }
+  }
+
+  setHome(i, anchor) {
+    const jitter = seededJitter(this.seed[i]);
+    this.homeX[i] = anchor.x + jitter[0] * 0.008;
+    this.homeY[i] = anchor.y + jitter[1] * 0.008;
+    this.homeZ[i] = anchor.z + jitter[2] * 0.006;
+  }
+
+  updateHomes(topology, blend) {
+    for (let i = 0; i < this.count; i++) {
+      const name = ZONE_NAMES[this.zone[i]];
+      const list = topology.zones[name] || topology.anchors;
+      const idx = Math.min(list.length - 1, Math.floor(this.u[i] * list.length));
+      this.setHome(i, applyBlendshape(list[idx], blend));
+    }
+  }
+
+  tick(dtMs, pose, quality) {
+    const yaw = pose.yaw || 0;
+    const pitch = pose.pitch || 0;
+    const roll = pose.roll || 0;
+    const cy = Math.cos(yaw), sy = Math.sin(yaw);
+    const cp = Math.cos(pitch), sp = Math.sin(pitch);
+    const cr = Math.cos(roll), sr = Math.sin(roll);
+    const spring = quality?.spring ?? 0.080;
+    const damping = quality?.damping ?? 0.88;
+
+    for (let i = 0; i < this.count; i++) {
+      let x = this.homeX[i], y = this.homeY[i], z = this.homeZ[i];
+      const xr = x * cr - y * sr;
+      const yr = x * sr + y * cr;
+      x = xr; y = yr;
+      const xy = x * cy + z * sy;
+      const zy = -x * sy + z * cy;
+      x = xy; z = zy;
+      const yp = y * cp - z * sp;
+      z = y * sp + z * cp;
+      y = yp;
+
+      const fov = 2.2;
+      const ps = fov / Math.max(0.25, fov - z);
+      const tx = x * ps;
+      const ty = y * ps;
+
+      this.vx[i] += (tx - this.x[i]) * spring / this.mass[i];
+      this.vy[i] += (ty - this.y[i]) * spring / this.mass[i];
+      this.vx[i] *= damping;
+      this.vy[i] *= damping;
+      this.x[i] += this.vx[i] * dtMs * 0.06;
+      this.y[i] += this.vy[i] * dtMs * 0.06;
+      this.depth[i] = z;
+      this.brightness[i] = clamp(0.25 + z * 0.35 + ps * 0.25, 0.05, 1);
+    }
+  }
+}
+
+function seededJitter(seed) {
+  let s = seed >>> 0;
+  const next = () => {
+    s ^= s << 13; s ^= s >>> 17; s ^= s << 5;
+    return ((s >>> 0) / 0xFFFFFFFF) * 2 - 1;
+  };
+  return [next(), next(), next()];
+}
+
+class SpatialHash2D {
+  constructor(cellSize = 0.025) {
+    this.cellSize = cellSize;
+    this.cells = new Map();
+  }
+
+  clear() { this.cells.clear(); }
+
+  key(x, y) {
+    return `${Math.floor(x / this.cellSize)},${Math.floor(y / this.cellSize)}`;
+  }
+
+  add(index, x, y) {
+    const key = this.key(x, y);
+    let bucket = this.cells.get(key);
+    if (!bucket) this.cells.set(key, bucket = []);
+    bucket.push(index);
+  }
+
+  nearby(x, y) {
+    const cx = Math.floor(x / this.cellSize);
+    const cy = Math.floor(y / this.cellSize);
+    const out = [];
+    for (let yy = cy - 1; yy <= cy + 1; yy++) {
+      for (let xx = cx - 1; xx <= cx + 1; xx++) {
+        const bucket = this.cells.get(`${xx},${yy}`);
+        if (bucket) out.push(...bucket);
+      }
+    }
+    return out;
+  }
+}
+
+class QualityController {
+  constructor() {
+    this.tier = "auto";
+    this.particles = matchMedia('(pointer: coarse)').matches ? 700 : 2600;
+    this.dpr = Math.min(devicePixelRatio || 1, matchMedia('(pointer: coarse)').matches ? 1.25 : 2);
+    this.fpsCap = 60;
+    this.spring = 0.080;
+    this.damping = 0.88;
+    this.effects = {
+      phosphor: true,
+      bloom: true,
+      oscilloscope: true,
+      spatialRepulsion: !matchMedia('(pointer: coarse)').matches
+    };
+    this.avgFrameMs = 16.7;
+  }
+
+  observeFrame(dtMs) {
+    this.avgFrameMs = damp(this.avgFrameMs, dtMs, 2.0, dtMs);
+    if (this.avgFrameMs > 24) this.drop();
+    else if (this.avgFrameMs < 13) this.raise();
+  }
+
+  drop() {
+    if (this.tier === "battery") return;
+    this.fpsCap = 30;
+    this.effects.bloom = false;
+    this.effects.spatialRepulsion = false;
+  }
+
+  raise() {
+    if (this.tier === "battery") return;
+    this.fpsCap = 60;
+    this.effects.bloom = true;
+  }
+
+  battery() {
+    this.tier = "battery";
+    this.fpsCap = 30;
+    this.effects.bloom = false;
+    this.effects.oscilloscope = false;
+    this.effects.spatialRepulsion = false;
+  }
+}
+
+class VisemeDriver {
+  constructor() {
+    this.shape = "neutral";
+    this.jaw = 0;
+  }
+
+  shapeAt(text, audioTime, duration, energy = 0) {
+    const idx = Math.floor((audioTime / Math.max(duration, 0.1)) * text.length);
+    const c = (text[idx] || '').toLowerCase();
+    if ('aæɑ'.includes(c)) this.shape = "A";
+    else if ('eɛi'.includes(c)) this.shape = "E";
+    else if ('oɔå'.includes(c)) this.shape = "O";
+    else if ('uʊy'.includes(c)) this.shape = "U";
+    else if ('mbpfvw'.includes(c)) this.shape = "M";
+    else if (c === ' ' || c === '.' || c === ',') this.shape = "neutral";
+    else this.shape = "E";
+    this.jaw = clamp(energy * 1.4);
+    return { shape: this.shape, jaw: this.jaw };
+  }
+
+  toBlend(viseme) {
+    return {
+      jawOpen: viseme.jaw + (viseme.shape === "A" ? 0.35 : 0) + (viseme.shape === "O" ? 0.22 : 0),
+      mouthRound: viseme.shape === "O" || viseme.shape === "U" ? 0.85 : 0,
+      mouthWide: viseme.shape === "E" ? 0.55 : 0,
+      smile: 0,
+      frown: 0
+    };
+  }
+}
+
+class Face3DEngine {
+  constructor({ count } = {}) {
+    this.quality = new QualityController();
+    this.topology = buildCanonicalMask("sepik");
+    this.particles = new ParticleField3D(count || this.quality.particles);
+    this.particles.assignStable(this.topology);
+    this.blend = { ...DEFAULT_BLEND };
+    this.emotion = { ...DEFAULT_EMOTION };
+    this.pose = { yaw: 0, pitch: 0, roll: 0 };
+    this.visemes = new VisemeDriver();
+  }
+
+  setMask(kind) {
+    this.topology = buildCanonicalMask(kind);
+    this.particles.assignStable(this.topology);
+  }
+
+  setEmotion(patch) {
+    this.emotion = { ...this.emotion, ...patch };
+    this.blend = deriveBlendFromEmotion(this.emotion, this.blend);
+  }
+
+  setBlend(patch) {
+    this.blend = { ...this.blend, ...patch };
+  }
+
+  setPose(patch) {
+    this.pose = { ...this.pose, ...patch };
+  }
+
+  speakFrame(text, audioTime, duration, energy = 0) {
+    const viseme = this.visemes.shapeAt(text, audioTime, duration, energy);
+    this.setBlend(this.visemes.toBlend(viseme));
+    return viseme;
+  }
+
+  tick(dtMs) {
+    this.quality.observeFrame(dtMs);
+    this.particles.updateHomes(this.topology, this.blend);
+    this.particles.tick(dtMs, this.pose, this.quality);
+  }
+
+  snapshot() {
+    return {
+      count: this.particles.count,
+      x: this.particles.x,
+      y: this.particles.y,
+      depth: this.particles.depth,
+      brightness: this.particles.brightness,
+      zone: this.particles.zone
+    };
+  }
+}
+
+window.MasterFace3D = Object.freeze({
+  ZONES,
+  ZONE_NAMES,
+  buildCanonicalMask,
+  applyBlendshape,
+  deriveBlendFromEmotion,
+  ParticleField3D,
+  SpatialHash2D,
+  QualityController,
+  VisemeDriver,
+  Face3DEngine
+});
+
+export {
+  ZONES,
+  ZONE_NAMES,
+  buildCanonicalMask,
+  applyBlendshape,
+  deriveBlendFromEmotion,
+  ParticleField3D,
+  SpatialHash2D,
+  QualityController,
+  VisemeDriver,
+  Face3DEngine
+};

--- a/MASTER/web/public/face3d_preview.js
+++ b/MASTER/web/public/face3d_preview.js
@@ -1,0 +1,69 @@
+"use strict";
+
+import { Face3DEngine } from '/face3d_engine.js';
+import { Face3DCanvasRenderer } from '/face3d_renderer.js';
+
+const enabled = new URLSearchParams(window.location.search).get('face3d') === '1';
+
+if (enabled) {
+  const canvas = document.getElementById('face');
+  const engine = new Face3DEngine();
+  const renderer = new Face3DCanvasRenderer(canvas);
+
+  let last = performance.now();
+  let t0 = last;
+  let maskIdx = 0;
+  const masks = ['sepik', 'asmat', 'baining', 'tolai', 'neutral'];
+
+  window.addEventListener('resize', () => renderer.resize(), { passive: true });
+
+  window.Face3DPreview = Object.freeze({ engine, renderer });
+
+  function moodFromTime(now) {
+    const t = (now - t0) * 0.001;
+    return {
+      arousal: 0.30 + Math.sin(t * 0.7) * 0.20,
+      valence: Math.sin(t * 0.33) * 0.65,
+      focus: 0.45 + Math.sin(t * 0.23) * 0.25,
+      confidence: 0.80 + Math.sin(t * 0.41) * 0.18,
+      fatigue: 0.08 + Math.max(0, Math.sin(t * 0.17)) * 0.20
+    };
+  }
+
+  function frame(now) {
+    const dt = Math.min(50, now - last);
+    last = now;
+    const t = (now - t0) * 0.001;
+
+    if (t > (maskIdx + 1) * 10) {
+      maskIdx = (maskIdx + 1) % masks.length;
+      engine.setMask(masks[maskIdx]);
+    }
+
+    engine.setEmotion(moodFromTime(now));
+    engine.setPose({
+      yaw: Math.sin(t * 0.37) * 0.34,
+      pitch: Math.sin(t * 0.29) * 0.13,
+      roll: Math.sin(t * 0.19) * 0.04
+    });
+
+    engine.setBlend({
+      blink: blinkEnvelope(t),
+      jawOpen: 0.08 + Math.max(0, Math.sin(t * 3.2)) * 0.18,
+      mouthRound: Math.max(0, Math.sin(t * 1.6)) * 0.35,
+      cheekRaise: Math.max(0, Math.sin(t * 0.8)) * 0.22
+    });
+
+    engine.tick(dt);
+    renderer.draw(engine.snapshot(), { neonBleed: Math.max(0, Math.sin(t * 1.7)) * 0.25 });
+    requestAnimationFrame(frame);
+  }
+
+  requestAnimationFrame(frame);
+}
+
+function blinkEnvelope(t) {
+  const phase = t % 4.2;
+  if (phase > 0.10) return 0;
+  return Math.sin((phase / 0.10) * Math.PI);
+}

--- a/MASTER/web/public/face3d_renderer.js
+++ b/MASTER/web/public/face3d_renderer.js
@@ -1,0 +1,199 @@
+"use strict";
+
+import { ZONE_NAMES } from '/face3d_engine.js';
+
+function clamp(v, lo = 0, hi = 1) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function parseRGB(rgb) {
+  if (Array.isArray(rgb)) return rgb;
+  return String(rgb || '255,255,255').split(',').map(Number).slice(0, 3);
+}
+
+const DEFAULT_PALETTE = Object.freeze({
+  shadow: '0,0,0',
+  midtone: '90,90,90',
+  highlight: '255,255,255',
+  accent: '170,210,255'
+});
+
+const ZONE_TINT = Object.freeze({
+  outlineL: [255, 255, 255], outlineR: [255, 255, 255],
+  eyeL: [210, 230, 255], eyeR: [210, 230, 255],
+  pupilL: [255, 255, 255], pupilR: [255, 255, 255],
+  browL: [210, 255, 210], browR: [210, 255, 210],
+  noseRidge: [230, 230, 230], noseFlare: [230, 230, 230],
+  mouth: [255, 160, 160], chin: [240, 240, 180],
+  crown: [180, 255, 255], cheekL: [255, 190, 210], cheekR: [255, 190, 210],
+  sideL: [230, 180, 255], sideR: [230, 180, 255]
+});
+
+class Face3DCanvasRenderer {
+  constructor(canvas, { scale = 0.82, lowRes = true } = {}) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d', { alpha: false });
+    this.scale = scale;
+    this.lowRes = lowRes;
+    this.width = 0;
+    this.height = 0;
+    this.dpr = 1;
+    this.lpx = document.createElement('canvas');
+    this.lctx = this.lpx.getContext('2d', { alpha: false });
+    this.fbuf = null;
+    this.zbuf = null;
+    this.bufSize = 0;
+    this.palette = DEFAULT_PALETTE;
+    this.dither = 'atkinson';
+    this.phosphor = true;
+    this.resize();
+  }
+
+  resize() {
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    this.width = w;
+    this.height = h;
+    this.dpr = dpr;
+    this.canvas.width = Math.max(1, Math.floor(w * dpr));
+    this.canvas.height = Math.max(1, Math.floor(h * dpr));
+    this.canvas.style.width = `${w}px`;
+    this.canvas.style.height = `${h}px`;
+    this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    const lw = this.lowRes ? Math.max(1, w >> 1) : w;
+    const lh = this.lowRes ? Math.max(1, h >> 1) : h;
+    this.lpx.width = lw;
+    this.lpx.height = lh;
+    this._ensureBuffers(lw * lh);
+  }
+
+  setPalette(palette) {
+    this.palette = { ...DEFAULT_PALETTE, ...palette };
+  }
+
+  setDither(mode) {
+    this.dither = mode === 'bayer' ? 'bayer' : 'atkinson';
+  }
+
+  draw(snapshot, state = {}) {
+    const lw = this.lpx.width;
+    const lh = this.lpx.height;
+    this._ensureBuffers(lw * lh);
+
+    const fbuf = this.fbuf;
+    const zbuf = this.zbuf;
+    const decay = this.phosphor ? 0.80 : 0.0;
+    const drain = this.phosphor ? 0.004 : 1.0;
+    for (let i = 0; i < fbuf.length; i++) {
+      fbuf[i] = Math.max(0, fbuf[i] * decay - drain);
+      zbuf[i] = 0;
+    }
+
+    const cx = lw * 0.5;
+    const cy = lh * 0.50;
+    const s = Math.min(lw, lh) * this.scale * 0.48;
+    const count = snapshot.count;
+
+    for (let i = 0; i < count; i++) {
+      const px = (cx + snapshot.x[i] * s) | 0;
+      const py = (cy + snapshot.y[i] * s) | 0;
+      if (px < 1 || px >= lw - 1 || py < 1 || py >= lh - 1) continue;
+
+      const depth = snapshot.depth ? snapshot.depth[i] : 0;
+      const bright = clamp(snapshot.brightness ? snapshot.brightness[i] : 0.6);
+      const zone = snapshot.zone ? snapshot.zone[i] : 0;
+      const idx = py * lw + px;
+      const val = Math.min(1, bright * (0.50 + depth * 0.18 + 0.45));
+
+      fbuf[idx] = Math.min(1, fbuf[idx] + val);
+      zbuf[idx] = zone;
+
+      if (bright > 0.72) {
+        fbuf[idx + 1] = Math.min(1, fbuf[idx + 1] + val * 0.32);
+        fbuf[idx - 1] = Math.min(1, fbuf[idx - 1] + val * 0.18);
+        fbuf[idx + lw] = Math.min(1, fbuf[idx + lw] + val * 0.20);
+      }
+    }
+
+    this._rasterize(state);
+    this.ctx.imageSmoothingEnabled = false;
+    this.ctx.fillStyle = '#000';
+    this.ctx.fillRect(0, 0, this.width, this.height);
+    this.ctx.drawImage(this.lpx, 0, 0, this.width, this.height);
+  }
+
+  _ensureBuffers(size) {
+    if (this.bufSize === size && this.fbuf && this.zbuf) return;
+    this.bufSize = size;
+    this.fbuf = new Float32Array(size);
+    this.ebuf = new Float32Array(size);
+    this.zbuf = new Uint8Array(size);
+  }
+
+  _rasterize(state) {
+    const lw = this.lpx.width;
+    const lh = this.lpx.height;
+    const img = this.lctx.getImageData(0, 0, lw, lh);
+    const data = img.data;
+    const fbuf = this.fbuf;
+    const zbuf = this.zbuf;
+    this.ebuf.fill(0);
+
+    const accent = parseRGB(this.palette.accent);
+    const highlight = parseRGB(this.palette.highlight);
+    const bayer = [0, 8, 2, 10, 12, 4, 14, 6, 3, 11, 1, 9, 15, 7, 13, 5];
+
+    for (let y = 0; y < lh; y++) {
+      for (let x = 0; x < lw; x++) {
+        const idx = y * lw + x;
+        let v = clamp(fbuf[idx] + (this.dither === 'atkinson' ? this.ebuf[idx] : 0));
+        let on;
+        if (this.dither === 'bayer') {
+          on = v > bayer[(y & 3) * 4 + (x & 3)] / 16;
+        } else {
+          on = v >= 0.5;
+        }
+
+        const out = idx * 4;
+        if (on) {
+          const zoneName = ZONE_NAMES[zbuf[idx]];
+          const tint = ZONE_TINT[zoneName] || highlight;
+          const mix = state.neonBleed ? clamp(state.neonBleed) : 0;
+          data[out] = lerp(tint[0], accent[0], mix) | 0;
+          data[out + 1] = lerp(tint[1], accent[1], mix) | 0;
+          data[out + 2] = lerp(tint[2], accent[2], mix) | 0;
+          data[out + 3] = 255;
+        } else {
+          data[out] = 0;
+          data[out + 1] = 0;
+          data[out + 2] = 0;
+          data[out + 3] = 255;
+        }
+
+        if (this.dither === 'atkinson') {
+          const err = (v - (on ? 1 : 0)) * 0.125;
+          if (x + 1 < lw) this.ebuf[idx + 1] += err;
+          if (x + 2 < lw) this.ebuf[idx + 2] += err;
+          if (y + 1 < lh) {
+            if (x > 0) this.ebuf[idx + lw - 1] += err;
+            this.ebuf[idx + lw] += err;
+            if (x + 1 < lw) this.ebuf[idx + lw + 1] += err;
+          }
+          if (y + 2 < lh) this.ebuf[idx + lw * 2] += err;
+        }
+      }
+    }
+
+    this.lctx.putImageData(img, 0, 0);
+  }
+}
+
+window.MasterFace3DRenderer = Object.freeze({ Face3DCanvasRenderer });
+
+export { Face3DCanvasRenderer };

--- a/MASTER/web/public/visual_bridge.js
+++ b/MASTER/web/public/visual_bridge.js
@@ -155,6 +155,27 @@
     }
   }
 
+  function bootExperimentalVisuals() {
+    const params = new URLSearchParams(window.location.search);
+    const face3d = params.get("face3d") === "1";
+    const clusters = face3d || params.get("clusters") === "1";
+
+    if (clusters && !window.MASTERClusterMiner) {
+      const script = document.createElement("script");
+      script.src = "/cluster_miner.js";
+      script.defer = true;
+      script.onload = () => emitVisual("clusters:ready", { topology: "neural", entropy: 0.18, confidence: 0.86, mode: "clusters" });
+      script.onerror = () => emitVisual("clusters:error", { topology: "serpent", entropy: 0.62, confidence: 0.36, mode: "error" });
+      document.head.appendChild(script);
+    }
+
+    if (face3d) {
+      import("/face3d_preview.js")
+        .then(() => emitVisual("face3d:ready", { topology: "papua-mask", entropy: 0.16, confidence: 0.88, mode: "face3d" }))
+        .catch(error => emitVisual("face3d:error", { topology: "serpent", entropy: 0.70, confidence: 0.30, mode: "error", raw: String(error?.message || error) }));
+    }
+  }
+
   window.MASTERVisual = {
     state,
     event: emitVisual,
@@ -164,5 +185,6 @@
 
   observeDomSignals();
   connectSse();
+  bootExperimentalVisuals();
   emitVisual("visual:ready", { topology: "papua-mask", entropy: 0.14, confidence: 0.92, mode: "ready" });
 })();


### PR DESCRIPTION
## Summary

Adds a modular Face3D particle engine, a retro canvas renderer, preview boot path, cluster mining, repo-topic cluster registries, and TTS runtime fixes.

## What changed

### Face3D / particles

- Adds `web/public/face3d_engine.js` with normalized 3D topology, semantic zones, stable particle assignment, typed-array particle storage, blendshapes, emotion mapping, spatial hash utilities, quality control, and a viseme driver.
- Adds `web/public/face3d_renderer.js` to render Face3D snapshots through a low-res phosphor/dither canvas path.
- Adds `web/public/face3d_preview.js`, gated by `?face3d=1`, for safe preview without replacing the live retro face.
- Updates `web/public/visual_bridge.js` to dynamically load `cluster_miner.js` for `?clusters=1`/`?face3d=1` and import `face3d_preview.js` for preview mode.

### Cluster mining

- Adds `web/public/cluster_miner.js` to group `master:visual`, `master:codebase`, and `master:rule_event` into cluster heat/confidence/evidence and emit `master:clusters`.
- Adds `data/visual_clusters.yml` for live visual/cognition clusters.
- Adds `data/repo_topic_clusters.yml` for broader repo-topic clusters, including token efficiency, provider economy, design architecture, WebGPU, bleeding-edge experimental repos, AGI agents, personal assistants, social intelligence, music/chord theory, lyricism/prosody, and ar5iv/arXiv radar.
- Expands `docs/face3d_engine.md` with migration and cluster integration guidance.

### TTS

- Fixes `Master::Voice::Speech.available?` so it reflects actual Edge/eSpeak availability.
- Adds `synthesize_audio` with audio bytes plus MIME metadata.
- Keeps `synthesize_bytes` backward-compatible.
- Falls back from Edge worker to eSpeak when available.
- Updates `/chat/tts` to serve the actual synthesized MIME type instead of always `audio/mpeg`.
- Adds tests for MP3/WAV MIME metadata and temp-file cleanup.

## Notes

This remains mostly additive and preview-gated. The live `face.js` renderer is not replaced; `?face3d=1` activates the new preview path.