### PR TITLE
Add chat photo upload with automatic postpro

### DIFF
--- a/MASTER/web/app/controllers/chat_controller.rb
+++ b/MASTER/web/app/controllers/chat_controller.rb
@@ -1,10 +1,26 @@
 # frozen_string_literal: true
 
+require "base64"
+require "fileutils"
+require "json"
 require "open3"
+require "rbconfig"
+require "securerandom"
 
 class ChatController < ApplicationController
   # CSRF guarded by SameSite=Strict session cookie set in AuthTier.
   skip_before_action :verify_authenticity_token, only: :command
+
+  PHOTO_UPLOAD_DIR = Rails.root.join("tmp", "chat_uploads")
+  PHOTO_MAX_BYTES = Integer(ENV.fetch("MASTER_PHOTO_MAX_BYTES", 12 * 1024 * 1024))
+  PHOTO_MIME_EXT = {
+    "image/jpeg" => ".jpg",
+    "image/png" => ".png",
+    "image/webp" => ".webp",
+    "image/heic" => ".heic",
+    "image/heif" => ".heif"
+  }.freeze
+  DEFAULT_POSTPRO_PRESET = ENV.fetch("MASTER_POSTPRO_PRESET", "portrait")
 
   def index
     @model = container[:agent].model.to_s.split("/").last
@@ -59,6 +75,46 @@ class ChatController < ApplicationController
     render json: result
   rescue StandardError => e
     render json: { changed: false, error: e.message }
+  end
+
+  def photo
+    upload = params[:photo]
+    return render(json: { error: "missing photo" }, status: :bad_request) unless upload.respond_to?(:read)
+
+    mime = upload.content_type.to_s.downcase
+    ext = PHOTO_MIME_EXT[mime]
+    return render(json: { error: "unsupported image type" }, status: :unsupported_media_type) unless ext
+
+    size = upload.respond_to?(:size) ? upload.size.to_i : 0
+    return render(json: { error: "photo too large" }, status: :payload_too_large) if size > PHOTO_MAX_BYTES
+
+    FileUtils.mkdir_p(PHOTO_UPLOAD_DIR)
+    cleanup_old_photos!
+
+    token = SecureRandom.hex(12)
+    safe_name = sanitize_filename(upload.original_filename.to_s, fallback_ext: ext)
+    original_path = PHOTO_UPLOAD_DIR.join("#{token}_orig#{ext}")
+    processed_path = PHOTO_UPLOAD_DIR.join("#{token}_#{DEFAULT_POSTPRO_PRESET}#{ext}")
+
+    File.binwrite(original_path, upload.read)
+    processed = postpro_photo(original_path.to_s, processed_path.to_s)
+    final_path = processed && File.file?(processed_path) ? processed_path : original_path
+
+    info = {
+      "token" => token,
+      "path" => final_path.to_s,
+      "original_path" => original_path.to_s,
+      "name" => safe_name,
+      "mime" => mime,
+      "processed" => final_path == processed_path,
+      "preset" => DEFAULT_POSTPRO_PRESET,
+      "created_at" => Time.now.utc.iso8601
+    }
+    File.write(PHOTO_UPLOAD_DIR.join("#{token}.json"), JSON.pretty_generate(info))
+    render json: { token: token, name: safe_name, processed: info["processed"], preset: DEFAULT_POSTPRO_PRESET }
+  rescue StandardError => e
+    Rails.logger.warn("photo upload failed: #{e.class}: #{e.message}")
+    render json: { error: "photo upload failed" }, status: 500
   end
 
   def message
@@ -117,6 +173,9 @@ class ChatController < ApplicationController
       ctx[:voice] = true if params[:voice].present?
       if (img = params[:image]).present?
         ctx[:image] = { data: img[:data].to_s, mime: img[:mime].to_s, name: img[:name].to_s }
+      elsif (token = params[:image_token]).present?
+        payload = uploaded_image_payload(token)
+        ctx[:image] = payload if payload
       end
 
       mutated_flag    = false
@@ -187,6 +246,63 @@ class ChatController < ApplicationController
   end
 
   private
+
+  def cleanup_old_photos!
+    cutoff = Time.now - 86_400
+    Dir.glob(PHOTO_UPLOAD_DIR.join("*")).each do |path|
+      File.delete(path) if File.file?(path) && File.mtime(path) < cutoff
+    end
+  rescue StandardError => e
+    Rails.logger.debug("photo cleanup skipped: #{e.message}")
+  end
+
+  def sanitize_filename(name, fallback_ext: ".jpg")
+    ext = File.extname(name.to_s).downcase
+    ext = fallback_ext if ext.empty?
+    stem = File.basename(name.to_s, ext).gsub(/[^A-Za-z0-9._-]+/, "_").sub(/\A[._-]+/, "")
+    stem = "photo" if stem.empty?
+    "#{stem}#{ext}"
+  end
+
+  def postpro_photo(input_path, output_path)
+    script = Rails.root.join("..", "tools", "postpro.rb").to_s
+    return false unless File.file?(script)
+
+    out, status = Open3.capture2e(
+      RbConfig.ruby,
+      script,
+      "--input", input_path,
+      "--output", output_path,
+      "--preset", DEFAULT_POSTPRO_PRESET,
+      chdir: Rails.root.join("..", "..").to_s
+    )
+    Rails.logger.info("postpro photo=#{File.basename(input_path)} status=#{status.exitstatus} out=#{out.lines.last}")
+    status.success?
+  rescue StandardError => e
+    Rails.logger.warn("postpro failed: #{e.class}: #{e.message}")
+    false
+  end
+
+  def uploaded_image_payload(token)
+    return nil unless token.to_s.match?(/\A[0-9a-f]{24}\z/)
+
+    meta_path = PHOTO_UPLOAD_DIR.join("#{token}.json")
+    return nil unless File.file?(meta_path)
+
+    meta = JSON.parse(File.read(meta_path))
+    path = meta["path"].to_s
+    return nil unless path.start_with?(PHOTO_UPLOAD_DIR.to_s)
+    return nil unless File.file?(path)
+
+    {
+      data: Base64.strict_encode64(File.binread(path)),
+      mime: meta["mime"].to_s.empty? ? "image/jpeg" : meta["mime"].to_s,
+      name: meta["name"].to_s.empty? ? File.basename(path) : meta["name"].to_s
+    }
+  rescue StandardError => e
+    Rails.logger.warn("uploaded_image_payload failed: #{e.class}: #{e.message}")
+    nil
+  end
 
   # Format any bus event as an OpenBSD dmesg(8)-style line.
   # Pattern: <subsystem><unit> at <bus>: <description>

--- a/MASTER/web/app/views/chat/index.html.erb
+++ b/MASTER/web/app/views/chat/index.html.erb
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no">
+  <%= csrf_meta_tags %>
   <meta name="theme-color" content="#000000">
   <meta name="master-runtime" content="face">
   <meta name="master-visual-profile" content="auto">
@@ -28,6 +29,8 @@
     <div id="chat-log" aria-live="polite" aria-relevant="additions text"></div>
   </main>
   <form id="zsh" role="search" aria-label="MASTER prompt" autocomplete="off">
+    <button id="photo-button" type="button" aria-label="Attach photo">+</button>
+    <input id="photo" type="file" accept="image/*" capture="environment" hidden>
     <span class="pp">visitor</span><span class="sep">@master</span><span class="sep2"> $ </span>
     <input id="zin" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" enterkeyhint="send" placeholder="ask anything" aria-label="Message">
   </form>

--- a/MASTER/web/app/views/chat/index.html.erb
+++ b/MASTER/web/app/views/chat/index.html.erb
@@ -20,6 +20,7 @@
   <link rel="modulepreload" href="/three.module.js">
   <link rel="modulepreload" href="/face.js">
   <link rel="stylesheet" href="/face.css">
+  <link rel="stylesheet" href="/photo_upload.css">
 </head>
 <body data-runtime-profile="boot" data-runtime-visible="true" data-visual-runtime="face">
   <canvas id="cognition-ecology" aria-hidden="true"></canvas>

--- a/MASTER/web/config/routes.rb
+++ b/MASTER/web/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get "dashboard/live", to: "dashboard#live"
   mount ActionCable.server => "/cable"
   get  "chat/message",  to: "chat#message"
+  post "chat/photo",    to: "chat#photo"
   get  "chat/enhance",  to: "chat#enhance"
   get  "chat/history", to: "chat#history"
   post "chat/command", to: "chat#command"

--- a/MASTER/web/public/chat.js
+++ b/MASTER/web/public/chat.js
@@ -119,8 +119,7 @@ async function sendMessageWithPhoto(text) {
   window._chatOnUser?.(text);
 
   const enhanced = await enhanceMessage(text);
-  const state = encodeURIComponent('idle|thinking|0|0');
-  const params = new URLSearchParams({ message: enhanced.text, state });
+  const params = new URLSearchParams({ message: enhanced.text, state: 'idle|thinking|0|0' });
   if (enhanced.preEnhanced) params.set('pre_enhanced', '1');
   if (_pendingPhoto?.token) params.set('image_token', _pendingPhoto.token);
 

--- a/MASTER/web/public/chat.js
+++ b/MASTER/web/public/chat.js
@@ -3,8 +3,12 @@
 const log   = document.getElementById('chat-log');
 const zsh   = document.getElementById('zsh');
 const input = document.getElementById('zin');
+const photoButton = document.getElementById('photo-button');
+const photoInput  = document.getElementById('photo');
 
 let _streamEl = null;
+let _evtSrc = null;
+let _pendingPhoto = null;
 
 function appendMsg(role, text = '') {
   const d = document.createElement('div');
@@ -73,8 +77,107 @@ window._chatOnDmesg = (line) => {
   setTimeout(() => { d.classList.add('dmesg-fade'); setTimeout(() => d.remove(), 800); }, 7000);
 };
 
+function csrfToken() {
+  return document.querySelector('meta[name="csrf-token"]')?.content || '';
+}
+
+function setPhotoState(state, text) {
+  if (!photoButton) return;
+  photoButton.dataset.state = state;
+  photoButton.textContent = text;
+}
+
+async function uploadPhoto(file) {
+  const form = new FormData();
+  form.append('photo', file);
+  setPhotoState('busy', '…');
+  const response = await fetch('/chat/photo', {
+    method: 'POST',
+    headers: { 'X-CSRF-Token': csrfToken() },
+    credentials: 'same-origin',
+    body: form
+  });
+  if (!response.ok) throw new Error(`photo upload failed: ${response.status}`);
+  _pendingPhoto = await response.json();
+  setPhotoState(_pendingPhoto.processed ? 'ready' : 'raw', '1');
+}
+
+async function enhanceMessage(text) {
+  try {
+    const r = await fetch(`/chat/enhance?message=${encodeURIComponent(text)}`);
+    const data = await r.json();
+    if (data.changed && data.enhanced && data.enhanced !== text) {
+      const chosen = await (window._chatConfirmEnhance?.(text, data.enhanced) ?? Promise.resolve(text));
+      return { text: chosen, preEnhanced: chosen === data.enhanced };
+    }
+  } catch (_) {}
+  return { text, preEnhanced: false };
+}
+
+async function sendMessageWithPhoto(text) {
+  if (_evtSrc) { try { _evtSrc.close(); } catch (_) {} }
+  window._chatOnUser?.(text);
+
+  const enhanced = await enhanceMessage(text);
+  const state = encodeURIComponent('idle|thinking|0|0');
+  const params = new URLSearchParams({ message: enhanced.text, state });
+  if (enhanced.preEnhanced) params.set('pre_enhanced', '1');
+  if (_pendingPhoto?.token) params.set('image_token', _pendingPhoto.token);
+
+  _pendingPhoto = null;
+  if (photoInput) photoInput.value = '';
+  setPhotoState('idle', '+');
+
+  _evtSrc = new EventSource(`/chat/message?${params.toString()}`);
+  _evtSrc.onmessage = (ev) => {
+    const raw = ev.data || '';
+    if (raw === '[DONE]') {
+      try { _evtSrc.close(); } catch (_) {}
+      window._chatOnDone?.();
+      return;
+    }
+    if (raw.startsWith('ERROR:')) {
+      window._chatOnChunk?.('\n' + raw + '\n');
+      window._chatOnError?.();
+      return;
+    }
+    window._chatOnChunk?.(raw);
+  };
+  _evtSrc.addEventListener('dmesg', (ev) => {
+    try { window._chatOnDmesg?.(JSON.parse(ev.data)); } catch (_) {}
+  });
+  _evtSrc.onerror = () => {
+    try { _evtSrc.close(); } catch (_) {}
+    window._chatOnError?.();
+  };
+}
+
+photoButton?.addEventListener('click', () => photoInput?.click());
+photoInput?.addEventListener('change', async () => {
+  const file = photoInput.files && photoInput.files[0];
+  if (!file) return;
+  try {
+    await uploadPhoto(file);
+  } catch (err) {
+    setPhotoState('idle', '+');
+    appendMsg('assistant', `photo upload failed: ${err.message}`);
+    window._chatOnDone?.();
+  }
+});
+
+zsh?.addEventListener('submit', (event) => {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  const text = input.value.trim();
+  if (!text) return;
+  input.value = '';
+  sendMessageWithPhoto(text);
+}, true);
+
 (function applyTier() {
   const tier = document.querySelector('meta[name=master-tier]')?.content || 'visitor';
   const pp = document.querySelector('#zsh .pp');
   if (pp) pp.textContent = tier === 'authenticated' ? 'dev' : 'visitor';
 })();
+
+setPhotoState('idle', '+');

--- a/MASTER/web/public/photo_upload.css
+++ b/MASTER/web/public/photo_upload.css
@@ -1,0 +1,33 @@
+#zsh {
+  gap: 8px;
+}
+
+#photo-button {
+  appearance: none;
+  border: 1px solid var(--face-fg);
+  background: transparent;
+  color: var(--face-fg);
+  font: inherit;
+  inline-size: 18px;
+  block-size: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+}
+
+#photo-button[data-state="busy"] {
+  opacity: 0.55;
+}
+
+#photo-button[data-state="ready"],
+#photo-button[data-state="raw"] {
+  background: var(--face-fg);
+  color: var(--face-bg);
+}
+
+#photo-button:focus-visible {
+  outline: 1px solid var(--face-fg);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary

- Add chat photo upload route and UI affordance
- Save uploaded photos under `MASTER/web/tmp/chat_uploads`
- Auto-run `MASTER/tools/postpro.rb --input --output --preset portrait`
- Attach processed image to the next chat message via `image_token`
- Add size cap, MIME allowlist, filename sanitization, token validation, and 24h temp cleanup
- Add focused photo upload styling without touching the large face runtime stylesheet

## Council / autofix notes

Initial self-review vetoed the branch because the frontend route existed without a controller endpoint. Autofix landed the missing `ChatController#photo`, image-token loading, and basic safety guards.

Current caution: postpro runs synchronously during upload. That is acceptable for the first vertical slice, but should move to background processing if photo volume or image size grows.