### PR TITLE
Add MASTER 2.0.1 Converge kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 OUTPUT_*.md
 *.gem
 *.rbc
+*.tgz
+*.tar.gz
 .bundle
 vendor/bundle
 

--- a/MASTER/README.md
+++ b/MASTER/README.md
@@ -1,8 +1,10 @@
-# MASTER
+# MASTER 2.0.1
 
 Constitutional AI runtime for any text artifact — code, prose, design, structure. Ruby. OpenBSD. Self-hosting.
 
 Models propose. The constitution validates. Convergence loops digest violations. Memory learns what fixes stick. Pressure fields track epistemic health. Providers compete by capability, cost, and evidence.
+
+2.0.1 adds a standalone Converge kernel: topologically ordered rules, oscillation tracking, append-only SQLite runtime ledger, event streaming, personas, and a particle face dashboard.
 
 ## Quickstart
 
@@ -15,6 +17,26 @@ bundle exec ruby bin/cli
 Pipe input for one-shot mode. The web face starts on port 53187 behind relayd at `https://ai.brgen.no`.
 
 Deploy: `doas zsh DEPLOY/openbsd/openbsd.sh`
+
+## Converge kernel
+
+```ruby
+require_relative "lib/converge"
+
+engine = Converge::Engine.new("data/converge_rules.yml")
+engine.subscribe { |event| warn(event.inspect) }
+engine.run(code: "", reply_text: "plain reply")
+```
+
+The kernel canon lives at `data/converge_rules.yml`. The existing scanner corpus remains in `data/rules.yml`.
+
+Core guarantees:
+
+- rules run in dependency order
+- convergence stops at a fixpoint or 16 cycles
+- repeated state signatures are recorded as feedback loops
+- every applied rule emits a runtime event
+- runtime deltas are stored in `~/.master/state.db`
 
 ## Architecture
 
@@ -94,7 +116,7 @@ First-hit `?token=…` is accepted once; the middleware sets an `HttpOnly; Secur
 
 ## Modules
 
-`now` · `loop` · `judge` · `voice` · `ground` · `reach` · `trace`
+`now` · `loop` · `judge` · `voice` · `ground` · `reach` · `trace` · `converge`
 
 Constitution lives in `data/`. Runtime state in `.master/`. Knowledge store at `.master/knowledge.sqlite3`.
 

--- a/MASTER/data/AGENTS.md
+++ b/MASTER/data/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS
+
+How MASTER governs.
+
+## The Engine
+
+Single convergence loop over a dependency-ordered rule graph.
+
+Every rule has:
+
+- id
+- type: scan | fix | render | audit
+- depends_on: list of rule ids
+- apply: Ruby code block that mutates context
+
+The engine evaluates rules in topological order until no rule produces a change. Maximum cycle count: 16.
+
+## The Canon
+
+The compatibility canon for the 2.0.1 kernel lives in `data/converge_rules.yml`. The existing scanner corpus remains in `data/rules.yml`.

--- a/MASTER/data/HEARTBEAT.md
+++ b/MASTER/data/HEARTBEAT.md
@@ -1,0 +1,7 @@
+# HEARTBEAT
+
+Standing tasks.
+
+- @hourly review open pull requests
+- @daily 09:00 bundle exec bundler-audit
+- @reboot dmesg > /var/log/dmesg.boot && upload to dmesgd

--- a/MASTER/data/SOUL.md
+++ b/MASTER/data/SOUL.md
@@ -1,0 +1,10 @@
+# SOUL
+
+Absolute tier. Inviolable.
+
+- Golden Rule: PRESERVE THEN IMPROVE NEVER BREAK.
+- Anti-simulation: SHA-256 on read, unified diff on write, command output on completion.
+- Protection tiers: operator override > rule enforcement > automatic fix.
+- Code rules: no ASCII art, no bracket status, no hedging.
+- Aesthetic: two registers. System events: terse, lowercase, dmesg-style. Operator replies: plain English, proper casing, full sentences. No decoration.
+- Particle face: living GPU swarm with spatial hash repulsion belongs to the canon.

--- a/MASTER/data/converge_rules.yml
+++ b/MASTER/data/converge_rules.yml
@@ -1,0 +1,127 @@
+# converge_rules.yml — MASTER 2.0.1 kernel canon
+
+rules:
+  - id: no_ascii_art
+    type: scan
+    depends_on: []
+    apply: |
+      ctx[:violations] ||= []
+      if ctx[:code].to_s.match?(/[═║╔╗╚╝▪●◆◇]/)
+        ctx[:violations] << { rule: "no_ascii_art", desc: "decorative ASCII art detected" }
+      end
+      ctx
+
+  - id: anti_hedging
+    type: scan
+    depends_on: []
+    apply: |
+      hedges = %w[will would could might maybe perhaps hopefully]
+      ctx[:violations] ||= []
+      if ctx[:reply_text].to_s.match?(/\b(#{hedges.join("|")})\b/i)
+        ctx[:violations] << { rule: "anti_hedging", desc: "hedging word found" }
+      end
+      ctx
+
+  - id: no_bracket_status
+    type: scan
+    depends_on: []
+    apply: |
+      ctx[:violations] ||= []
+      if ctx[:output].to_s.match?(/\[(ok|err|warn|info)\]/i)
+        ctx[:violations] << { rule: "no_bracket_status", desc: "use prefix label" }
+      end
+      ctx
+
+  - id: sha256_on_read
+    type: audit
+    depends_on: []
+    apply: |
+      ctx[:violations] ||= []
+      if ctx[:file_read] && !ctx[:file_hash]
+        ctx[:violations] << { rule: "sha256_on_read", desc: "read without SHA-256" }
+      end
+      ctx
+
+  - id: unified_diff_on_write
+    type: audit
+    depends_on: []
+    apply: |
+      ctx[:violations] ||= []
+      if ctx[:file_written] && !ctx[:diff_generated]
+        ctx[:violations] << { rule: "unified_diff_on_write", desc: "write without unified diff" }
+      end
+      ctx
+
+  - id: kernel_voice
+    type: render
+    depends_on: [no_ascii_art, anti_hedging, no_bracket_status]
+    apply: |
+      if ctx[:event]&.dig(:type) == :system
+        ctx[:rendered_output] = "ok: #{ctx[:event][:desc]}"
+      end
+      ctx
+
+  - id: face_render
+    type: render
+    depends_on: [kernel_voice]
+    apply: |
+      if ctx[:persona_config]&.dig("face", "enabled")
+        ctx[:events] << { type: :face_state, payload: { state: ctx[:engine_state] || :idle } }
+      end
+      ctx
+
+  - id: molt_timer
+    type: render
+    depends_on: []
+    apply: |
+      ctx[:molt_timer] ||= 0
+      ctx[:molt_timer] += 1 if ctx[:heartbeat_fired]
+      ctx
+
+  - id: molt
+    type: render
+    depends_on: [molt_timer, kernel_voice]
+    apply: |
+      if ctx[:molt_timer].to_i >= 168
+        ctx[:molt_output] = {
+          action: :propose,
+          path: "data/rules.proposed.yml",
+          prompt: "Rebuild MASTER from scratch as minimal constitutional YAML."
+        }
+        ctx[:molt_timer] = 0
+        ctx[:events] << { type: :molt_proposed, payload: { path: "data/rules.proposed.yml" } }
+      end
+      ctx
+
+  - id: advisor_pattern
+    type: render
+    depends_on: [kernel_voice]
+    apply: |
+      if ctx[:task_complexity].to_i > 1
+        ctx[:advisor_plan] = {
+          prompt: "You are an advisor. Give advice only. TASK: #{ctx[:task_description]}",
+          status: :awaiting_plan
+        }
+        ctx[:execution_gated] = true
+      end
+      ctx
+
+  - id: free_model_guardrails
+    type: scan
+    depends_on: []
+    apply: |
+      ctx[:violations] ||= []
+      if ctx[:file_operation] == "write" && ctx[:file_exists]
+        ctx[:violations] << { rule: "free_model_guardrails", desc: "write on existing file blocked" }
+      end
+      if ctx[:file_path].to_s.match?(%r{^/(bin|etc|usr|var|tmp|dev|proc|sys)/})
+        ctx[:violations] << { rule: "free_model_guardrails", desc: "absolute system path blocked" }
+      end
+      ctx
+
+  - id: telemetry_heartbeat_sync
+    type: audit
+    depends_on: []
+    apply: |
+      ctx[:telemetry_synchronized] = File.exist?(File.expand_path("~/.master/state.db"))
+      ctx

--- a/MASTER/data/personas/brutalist.yml
+++ b/MASTER/data/personas/brutalist.yml
@@ -1,0 +1,8 @@
+name: brutalist
+voice:
+  enabled: false
+face:
+  enabled: false
+web:
+  enabled: true
+  port: 3737

--- a/MASTER/data/personas/rachel.yml
+++ b/MASTER/data/personas/rachel.yml
@@ -1,0 +1,15 @@
+name: rachel
+voice:
+  enabled: true
+  provider: elevenlabs
+  voice_id: rachel
+  style: warm_friend
+face:
+  enabled: true
+  mood_colors:
+    clean: "#00FF00"
+    warning: "#FFD700"
+    error: "#FF0000"
+web:
+  enabled: true
+  port: 3737

--- a/MASTER/lib/converge.rb
+++ b/MASTER/lib/converge.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "converge/converge"

--- a/MASTER/lib/converge/canon.rb
+++ b/MASTER/lib/converge/canon.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Converge
+  class Canon
+    class CyclicDependencyError < StandardError; end
+    class MissingDependencyError < StandardError; end
+
+    include TSort
+
+    def self.load(path)
+      raw = YAML.safe_load_file(path, permitted_classes: [Symbol], aliases: true)
+      entries = normalize_entries(raw)
+      new(entries).topologically_sorted
+    end
+
+    def self.normalize_entries(raw)
+      rules = raw.fetch("rules")
+      return rules if rules.is_a?(Array)
+
+      rules.values.flat_map { |group| group.is_a?(Array) ? group : [] }
+    end
+
+    def initialize(entries)
+      @rules = entries.map { |entry| Rule.new(entry) }
+      @rule_map = @rules.to_h { |rule| [rule.id, rule] }
+      validate_dependencies!
+    end
+
+    def topologically_sorted
+      tsort
+    rescue TSort::Cyclic => error
+      raise CyclicDependencyError, "cycle detected: #{error.message}"
+    end
+
+    def tsort_each_node(&block)
+      @rules.each(&block)
+    end
+
+    def tsort_each_child(rule, &block)
+      rule.depends_on.each { |dependency| block.call(@rule_map.fetch(dependency)) }
+    end
+
+    private
+
+    def validate_dependencies!
+      missing = @rules.flat_map(&:depends_on).uniq - @rule_map.keys
+      return if missing.empty?
+
+      raise MissingDependencyError, "missing rule dependencies: #{missing.join(", ")}"
+    end
+  end
+end

--- a/MASTER/lib/converge/converge.rb
+++ b/MASTER/lib/converge/converge.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "json"
+require "yaml"
+require "tsort"
+
+module Converge
+  autoload :Canon, "converge/canon"
+  autoload :Engine, "converge/engine"
+  autoload :EventStream, "converge/event_stream"
+  autoload :Rule, "converge/rule"
+end

--- a/MASTER/lib/converge/engine.rb
+++ b/MASTER/lib/converge/engine.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "json"
+require "set"
+require "sqlite3"
+
+module Converge
+  class Engine
+    MAX_CYCLES = 16
+
+    attr_reader :rules, :event_stream, :db
+
+    def initialize(canon_path)
+      @rules = Canon.load(canon_path)
+      @event_stream = EventStream.new
+      @context = {
+        violations: [],
+        events: @event_stream,
+        execution_depth: 0,
+        tracking_hashes: Set.new
+      }
+      init_storage
+    end
+
+    def run(initial_context = {})
+      @context.merge!(initial_context)
+      cycles = 0
+
+      loop do
+        changed = apply_rules_once
+        cycles += 1
+        @context[:execution_depth] = cycles
+        break unless changed && cycles < MAX_CYCLES
+      end
+
+      @event_stream.emit(:convergence_complete, cycles: cycles)
+      @context
+    end
+
+    def subscribe(&block)
+      @event_stream.subscribe(&block)
+    end
+
+    private
+
+    def apply_rules_once
+      changed = false
+
+      @rules.each do |rule|
+        @db.transaction do
+          before = Marshal.dump(serializable_context)
+          apply_rule(rule)
+          after = Marshal.dump(serializable_context)
+          next if after == before
+
+          log_state_delta(rule.id, after)
+          changed = true
+        end
+      end
+
+      changed
+    end
+
+    def apply_rule(rule)
+      @context = rule.apply(@context.dup)
+      track_state_hashes(rule.id)
+    rescue StandardError => error
+      violation = { rule: rule.id, error: error.message }
+      @context[:violations] << violation
+      @event_stream.emit(:violation, violation)
+    end
+
+    def init_storage
+      db_path = File.expand_path("~/.master/state.db")
+      FileUtils.mkdir_p(File.dirname(db_path))
+      @db = SQLite3::Database.new(db_path, timeout: 5_000)
+      @db.execute_batch <<~SQL
+        CREATE TABLE IF NOT EXISTS runtime_ledger (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          rule_id TEXT,
+          delta_blob TEXT,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE IF NOT EXISTS feedback_loops (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          signature TEXT UNIQUE,
+          hit_count INTEGER DEFAULT 1,
+          updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+      SQL
+    end
+
+    def track_state_hashes(rule_id)
+      current_hash = Digest::SHA256.hexdigest(Marshal.dump(serializable_context))
+      signature = "#{rule_id}:#{current_hash}"
+
+      if @context[:tracking_hashes].include?(signature)
+        @db.execute(
+          "INSERT INTO feedback_loops (signature) VALUES (?) ON CONFLICT(signature) DO UPDATE SET hit_count = hit_count + 1, updated_at = CURRENT_TIMESTAMP",
+          [signature]
+        )
+        raise "oscillation_detected: rule #{rule_id} generated a cyclical state mutation"
+      end
+
+      @context[:tracking_hashes] << signature
+    end
+
+    def log_state_delta(rule_id, current_dump)
+      payload = {
+        rule: rule_id,
+        sha256: Digest::SHA256.hexdigest(current_dump),
+        violations_count: @context[:violations]&.size || 0,
+        timestamp: Time.now.to_i
+      }
+      @db.execute("INSERT INTO runtime_ledger (rule_id, delta_blob) VALUES (?, ?)", [rule_id, JSON.generate(payload)])
+      @event_stream.emit(:rule_applied, payload)
+    end
+
+    def serializable_context
+      @context.reject { |key, _| [:events, :tracking_hashes].include?(key) }
+    end
+  end
+end

--- a/MASTER/lib/converge/event_stream.rb
+++ b/MASTER/lib/converge/event_stream.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Converge
+  class EventStream
+    attr_reader :log
+
+    def initialize
+      @subscribers = []
+      @log = []
+    end
+
+    def emit(event_type, payload = {})
+      entry = { type: event_type.to_sym, payload: payload, timestamp: Time.now.utc }
+      @log << entry
+      @subscribers.each { |subscriber| subscriber.call(entry) }
+      entry
+    end
+
+    def subscribe(&block)
+      @subscribers << block if block
+    end
+
+    def <<(entry)
+      emit(entry.fetch(:type), entry.fetch(:payload, entry.reject { |key, _| key == :type }))
+    end
+  end
+end

--- a/MASTER/lib/converge/rule.rb
+++ b/MASTER/lib/converge/rule.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Converge
+  class Rule
+    attr_reader :id, :type, :depends_on, :apply_block, :config
+
+    def initialize(entry)
+      @id = entry.fetch("id").to_s
+      @type = (entry["type"] || entry["tier"] || "scan").to_s
+      @depends_on = Array(entry["depends_on"]).map(&:to_s)
+      @apply_block = entry["apply"]
+      @config = entry.fetch("config", {})
+      @raw = entry
+    end
+
+    def apply(context)
+      return context unless apply_block
+
+      instance_exec(context, &proc_block)
+    end
+
+    private
+
+    def proc_block
+      @proc_block ||= TOPLEVEL_BINDING.eval("proc { |ctx| #{apply_block}\n}")
+    end
+  end
+end

--- a/MASTER/public/dashboard.html
+++ b/MASTER/public/dashboard.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MASTER particle face</title>
+<style>
+:root { --bg: #0a0a0a; --text: #c0c0c0; }
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: var(--bg); color: var(--text); height: 100vh; overflow: hidden; font-family: "Courier New", monospace; }
+canvas { width: 100vw; height: 100vh; display: block; }
+#status { position: absolute; bottom: 1rem; left: 1rem; font-size: 12px; text-transform: lowercase; opacity: 0.7; }
+</style>
+</head>
+<body>
+<canvas id="face"></canvas>
+<div id="status">initializing particle matrix...</div>
+<script>
+(() => {
+  const canvas = document.getElementById("face");
+  const statusEl = document.getElementById("status");
+  const gl = canvas.getContext("webgl2", { alpha: false, antialias: false });
+  if (!gl) { statusEl.textContent = "err: webgl2 missing"; return; }
+
+  const vertexSource = `#version 300 es
+    uniform float u_time;
+    uniform float u_bias;
+    uniform float u_freq;
+    in vec2 a_pos;
+    out float v_life;
+    void main() {
+      v_life = sin(u_time * 0.005 + a_pos.x);
+      float dynamicBias = u_bias + u_freq * 0.1;
+      vec2 ring = vec2(cos(a_pos.x + u_time * 0.002), sin(a_pos.x + u_time * 0.002)) * (0.5 + dynamicBias * 0.1);
+      gl_Position = vec4(mix(a_pos, ring, 0.6), 0.0, 1.0);
+      gl_PointSize = 1.8;
+    }`;
+
+  const fragmentSource = `#version 300 es
+    precision highp float;
+    uniform vec3 u_color;
+    in float v_life;
+    out vec4 outColor;
+    void main() { outColor = vec4(u_color.r, u_color.g + v_life * 0.1, u_color.b, 0.85); }`;
+
+  function shader(source, type) {
+    const compiled = gl.createShader(type);
+    gl.shaderSource(compiled, source);
+    gl.compileShader(compiled);
+    if (!gl.getShaderParameter(compiled, gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(compiled));
+    return compiled;
+  }
+
+  const program = gl.createProgram();
+  gl.attachShader(program, shader(vertexSource, gl.VERTEX_SHADER));
+  gl.attachShader(program, shader(fragmentSource, gl.FRAGMENT_SHADER));
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(program));
+  gl.useProgram(program);
+
+  const particleCount = 16384;
+  const positions = new Float32Array(particleCount * 2);
+  const velocities = new Float32Array(particleCount * 2);
+  for (let index = 0; index < particleCount; index += 1) {
+    positions[index * 2] = (Math.random() - 0.5) * 2.0;
+    positions[index * 2 + 1] = (Math.random() - 0.5) * 2.0;
+  }
+
+  const buffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+  gl.bufferData(gl.ARRAY_BUFFER, positions, gl.DYNAMIC_DRAW);
+  const location = gl.getAttribLocation(program, "a_pos");
+  gl.enableVertexAttribArray(location);
+  gl.vertexAttribPointer(location, 2, gl.FLOAT, false, 0, 0);
+
+  const uTime = gl.getUniformLocation(program, "u_time");
+  const uBias = gl.getUniformLocation(program, "u_bias");
+  const uFreq = gl.getUniformLocation(program, "u_freq");
+  const uColor = gl.getUniformLocation(program, "u_color");
+
+  const gridResolution = 64;
+  const grid = Array.from({ length: gridResolution * gridResolution }, () => []);
+  let color = [0.0, 0.9, 0.4];
+  let bias = 0.0;
+
+  function spatialRepulsion() {
+    for (const cell of grid) cell.length = 0;
+    for (let index = 0; index < particleCount; index += 1) {
+      const x = positions[index * 2];
+      const y = positions[index * 2 + 1];
+      const cellX = Math.max(0, Math.min(gridResolution - 1, Math.floor((x + 1) * 0.5 * gridResolution)));
+      const cellY = Math.max(0, Math.min(gridResolution - 1, Math.floor((y + 1) * 0.5 * gridResolution)));
+      grid[cellY * gridResolution + cellX].push(index);
+    }
+
+    for (let index = 0; index < particleCount; index += 1) {
+      const x = positions[index * 2];
+      const y = positions[index * 2 + 1];
+      const cellX = Math.max(0, Math.min(gridResolution - 1, Math.floor((x + 1) * 0.5 * gridResolution)));
+      const cellY = Math.max(0, Math.min(gridResolution - 1, Math.floor((y + 1) * 0.5 * gridResolution)));
+      for (let yy = -1; yy <= 1; yy += 1) {
+        for (let xx = -1; xx <= 1; xx += 1) {
+          const nx = cellX + xx;
+          const ny = cellY + yy;
+          if (nx < 0 || ny < 0 || nx >= gridResolution || ny >= gridResolution) continue;
+          for (const other of grid[ny * gridResolution + nx]) {
+            if (other === index) continue;
+            const ox = positions[other * 2];
+            const oy = positions[other * 2 + 1];
+            const dx = x - ox;
+            const dy = y - oy;
+            const distance2 = dx * dx + dy * dy;
+            if (distance2 > 0.0 && distance2 < 0.0009) {
+              velocities[index * 2] += dx * 0.0008 / distance2;
+              velocities[index * 2 + 1] += dy * 0.0008 / distance2;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  function resize() {
+    if (canvas.width === window.innerWidth && canvas.height === window.innerHeight) return;
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+  }
+
+  function draw(time) {
+    resize();
+    spatialRepulsion();
+    for (let index = 0; index < particleCount; index += 1) {
+      const px = index * 2;
+      const py = px + 1;
+      velocities[px] *= 0.94;
+      velocities[py] *= 0.94;
+      positions[px] += velocities[px];
+      positions[py] += velocities[py];
+      if (positions[px] < -1 || positions[px] > 1) velocities[px] *= -1;
+      if (positions[py] < -1 || positions[py] > 1) velocities[py] *= -1;
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, positions);
+    gl.clearColor(0.04, 0.04, 0.04, 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.uniform1f(uTime, time);
+    gl.uniform1f(uBias, bias);
+    gl.uniform1f(uFreq, 0.0);
+    gl.uniform3fv(uColor, color);
+    gl.drawArrays(gl.POINTS, 0, particleCount);
+    requestAnimationFrame(draw);
+  }
+
+  statusEl.textContent = "ok: swarm linked with spatial repulsion";
+  const events = new EventSource("/events");
+  events.addEventListener("face_state", (event) => {
+    const data = JSON.parse(event.data);
+    statusEl.textContent = data.state || "idle";
+    if (data.state === "speaking") color = [0.0, 0.7, 0.9];
+    else if (data.state === "error") color = [0.9, 0.1, 0.1];
+    else color = [0.0, 0.9, 0.4];
+  });
+  events.onerror = () => { statusEl.textContent = "err: stream disconnected"; };
+  requestAnimationFrame(draw);
+})();
+</script>
+</body>
+</html>

--- a/MASTER/spec/converge/engine_spec.rb
+++ b/MASTER/spec/converge/engine_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "tmpdir"
+require_relative "../../lib/converge"
+
+class ConvergeEngineSpec < Minitest::Test
+  def with_home
+    Dir.mktmpdir do |dir|
+      old_home = ENV["HOME"]
+      ENV["HOME"] = dir
+      yield
+    ensure
+      ENV["HOME"] = old_home
+    end
+  end
+
+  def test_runs_convergence
+    with_home do
+      engine = Converge::Engine.new(File.expand_path("../../data/converge_rules.yml", __dir__))
+      result = engine.run(code: "", reply_text: "plain reply")
+      assert result.key?(:violations)
+    end
+  end
+
+  def test_emits_events_to_subscribers
+    with_home do
+      engine = Converge::Engine.new(File.expand_path("../../data/converge_rules.yml", __dir__))
+      events = []
+      engine.subscribe { |event| events << event }
+      engine.run(code: "")
+      refute_empty events
+    end
+  end
+end


### PR DESCRIPTION
Adds a corrected MASTER 2.0.1 Converge kernel as an additive implementation against the real pub4 layout.

What changed:

- Adds `MASTER/lib/converge*` kernel files.
- Adds topological canon loading without ActiveSupport `index_by`.
- Adds event stream `subscribe` and `<<` support.
- Adds oscillation tracking and SQLite runtime ledger.
- Adds `MASTER/data/converge_rules.yml` instead of overwriting the existing large scanner corpus in `MASTER/data/rules.yml`.
- Adds SOUL, AGENTS, HEARTBEAT docs.
- Adds persona configs.
- Adds `MASTER/public/dashboard.html` particle face with spatial repulsion.
- Adds Minitest coverage for the new engine.
- Updates `MASTER/README.md` and `.gitignore`.

Important corrections versus the pasted patch:

- Did not include invalid Markdown-link-corrupted Ruby like `[rule.id](http://rule.id/)`.
- Did not add `gem 'converge', path: ...` because there is no gemspec and the kernel is loaded with `require_relative`.
- Did not replace the existing MASTER entrypoint because this repo uses `MASTER/bin/cli`, not the pasted `bin/master` layout.
- Did not add incomplete `MIDIExporter` / `AudioRenderer` placeholders.
- Did not overwrite `MASTER/data/rules.yml`; the current file is a large existing scanner corpus, so the new kernel canon is isolated in `MASTER/data/converge_rules.yml`.

Verification available from connector compare:

- 16 commits ahead.
- 16 changed files.
- Additive kernel files plus docs/dashboard/spec.

Caveat:

The branch was created from commit `e8391a56e65e7afa8cc4cbbededacec0504cbccd`. The repository `main` advanced afterward, so the PR branch is currently behind `main`. Rebase/update branch before merge if GitHub reports conflicts.