### PR TITLE
Run MASTER autofix through MASTER before DEPLOY autofix

### DIFF
--- a/.github/workflows/master-through-master.yml
+++ b/.github/workflows/master-through-master.yml
@@ -1,13 +1,15 @@
 name: MASTER through MASTER
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
 
 jobs:
-  master-self-scan:
-    name: MASTER scans MASTER
+  master-self-fix:
+    name: MASTER autofixes MASTER
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -21,16 +23,24 @@ jobs:
           bundler-cache: true
           working-directory: MASTER
 
-      - name: Run MASTER self-scan
+      - name: Run MASTER self-autofix
         working-directory: MASTER
         run: |
-          printf '/scan .\n' | bundle exec ruby bin/cli
+          printf '/fix .\n' | bundle exec ruby bin/cli
 
-  deploy-scan:
-    name: MASTER scans DEPLOY
+      - name: Show MASTER autofix diff
+        run: |
+          git diff -- MASTER
+
+      - name: Fail if MASTER autofix changed files
+        run: |
+          git diff --exit-code -- MASTER
+
+  deploy-fix:
+    name: MASTER autofixes DEPLOY
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: master-self-scan
+    needs: master-self-fix
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +52,15 @@ jobs:
           bundler-cache: true
           working-directory: MASTER
 
-      - name: Run DEPLOY scan through MASTER
+      - name: Run DEPLOY autofix through MASTER
         working-directory: MASTER
         run: |
-          printf '/scan ../DEPLOY\n' | bundle exec ruby bin/cli
+          printf '/fix ../DEPLOY\n' | bundle exec ruby bin/cli
+
+      - name: Show DEPLOY autofix diff
+        run: |
+          git diff -- DEPLOY MASTER
+
+      - name: Fail if DEPLOY autofix changed files
+        run: |
+          git diff --exit-code -- DEPLOY MASTER

--- a/.github/workflows/master-through-master.yml
+++ b/.github/workflows/master-through-master.yml
@@ -1,0 +1,48 @@
+name: MASTER through MASTER
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  master-self-scan:
+    name: MASTER scans MASTER
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: MASTER
+
+      - name: Run MASTER self-scan
+        working-directory: MASTER
+        run: |
+          printf '/scan .\n' | bundle exec ruby bin/cli
+
+  deploy-scan:
+    name: MASTER scans DEPLOY
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: master-self-scan
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: MASTER
+
+      - name: Run DEPLOY scan through MASTER
+        working-directory: MASTER
+        run: |
+          printf '/scan ../DEPLOY\n' | bundle exec ruby bin/cli


### PR DESCRIPTION
Adds a GitHub Actions workflow that gates DEPLOY autofix behind a MASTER self-autofix.

Order:

1. `MASTER` autofixes `MASTER` with `printf '/fix .\n' | bundle exec ruby bin/cli` from `MASTER/`.
2. The workflow shows `git diff -- MASTER` and fails if the autofix changed files, preserving a visible patch instead of silently mutating CI state.
3. Only if MASTER is clean, `MASTER` autofixes `DEPLOY` with `printf '/fix ../DEPLOY\n' | bundle exec ruby bin/cli`.
4. The workflow shows `git diff -- DEPLOY MASTER` and fails if files changed.

This runs MASTER through MASTER first, then DEPLOY through MASTER, with command-output and diff evidence.