### PR TITLE
[codex] Guard TTS backend failures

### DIFF
--- a/MASTER/bin/tts-worker
+++ b/MASTER/bin/tts-worker
@@ -12,6 +12,7 @@
 
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 require "bundler/setup"
+require "eventmachine"
 require "rb_edge_tts"
 require "faye/websocket"
 require "json"
@@ -31,7 +32,15 @@ def synth(voice, rate, pitch, text, out_path)
   File.exist?(out_path) && File.size(out_path) > 0
 end
 
+def require_eventmachine_ssl!
+  return unless EventMachine.respond_to?(:ssl?) && !EventMachine.ssl?
+
+  warn "tts-worker: EventMachine SSL support unavailable; reinstall eventmachine with OpenSSL support or install espeak"
+  exit 69
+end
+
 if ARGV[0] == "--daemon"
+  require_eventmachine_ssl!
   sock_path = ARGV[1] or abort "tts-worker --daemon: missing SOCKET_PATH"
   FileUtils.mkdir_p(File.dirname(sock_path))
   File.unlink(sock_path) rescue nil
@@ -77,6 +86,7 @@ if text.to_s.strip.empty?
   warn "tts-worker: empty stdin"
   exit 65
 end
+require_eventmachine_ssl!
 
 begin
   ok = synth(voice, rate, pitch, text, out_path)

--- a/MASTER/lib/voice/speech.rb
+++ b/MASTER/lib/voice/speech.rb
@@ -5,6 +5,7 @@ require "fileutils"
 require "open3"
 require "socket"
 require "json"
+require "timeout"
 
 module Master
   module Voice
@@ -12,7 +13,9 @@ module Master
       WORKER = File.expand_path("../../bin/tts-worker", __dir__)
       EDGE_TTS = File.executable?(WORKER)
       TTS_SOCKET = File.expand_path("../../.master/tts.sock", __dir__)
-      ESPEAK = %w[/usr/bin/espeak /usr/local/bin/espeak].find { |p| File.executable?(p) }
+      ESPEAK_PATHS = %w[/usr/bin/espeak /usr/local/bin/espeak].freeze
+      ESPEAK = ESPEAK_PATHS.find { |p| File.executable?(p) }
+      WORKER_TIMEOUT = 20
 
       Audio = Struct.new(:bytes, :mime_type, keyword_init: true)
 
@@ -69,7 +72,32 @@ module Master
       module_function
 
       def available?
-        EDGE_TTS || !ESPEAK.nil?
+        edge_tts_available? || !espeak_path.nil?
+      end
+
+      def edge_tts_available?
+        worker_executable? && eventmachine_ssl_available?
+      end
+
+      def worker_executable?
+        File.executable?(WORKER)
+      end
+
+      def espeak_path
+        ESPEAK_PATHS.find { |p| File.executable?(p) }
+      end
+
+      def eventmachine_ssl_available?
+        require "eventmachine"
+        return true unless EventMachine.respond_to?(:ssl?)
+
+        EventMachine.ssl?
+      rescue LoadError => e
+        warn_tts("edge unavailable: eventmachine cannot be loaded (#{e.message})")
+        false
+      rescue StandardError => e
+        warn_tts("edge availability probe failed: #{e.class}: #{e.message}")
+        false
       end
 
       def default_voice
@@ -165,12 +193,12 @@ module Master
         # Use the resolved config (applies Osman character when needed)
         style_config = style_config_for(voice, style)
 
-        if EDGE_TTS
+        if edge_tts_available?
           path = synthesize_edge(text_str, voice: voice, style_config: style_config)
           return path if path
         end
 
-        synthesize_espeak(text_str) if ESPEAK
+        synthesize_espeak(text_str) if espeak_path
       end
 
       def synthesize_audio(text, **opts)
@@ -197,13 +225,28 @@ module Master
         sock_path = synthesize_edge_socket(text, voice_name, style_config, audio_path)
         return sock_path if sock_path
 
-        _out, _err, status = Open3.capture3(
-          WORKER, voice_name, style_config[:rate], style_config[:pitch], audio_path,
-          stdin_data: text.to_s
-        )
-        return unless status.success?
+        timeout = worker_timeout
+        _out, err, status = Timeout.timeout(timeout) do
+          Open3.capture3(
+            WORKER, voice_name, style_config[:rate], style_config[:pitch], audio_path,
+            stdin_data: text.to_s
+          )
+        end
+        unless status.success?
+          warn_tts("edge worker failed: #{err.to_s.strip}") unless err.to_s.strip.empty?
+          return cleanup_failed_audio(audio_path)
+        end
 
-        (File.exist?(audio_path) && File.size(audio_path) > 0) ? audio_path : nil
+        return audio_path if File.exist?(audio_path) && File.size(audio_path) > 0
+
+        warn_tts("edge worker produced empty audio")
+        cleanup_failed_audio(audio_path)
+      rescue Timeout::Error
+        warn_tts("edge worker timed out after #{worker_timeout}s")
+        cleanup_failed_audio(audio_path)
+      rescue StandardError => e
+        warn_tts("edge worker error: #{e.class}: #{e.message}")
+        cleanup_failed_audio(audio_path)
       end
 
       def synthesize_edge_socket(text, voice_name, style_config, audio_path)
@@ -215,23 +258,53 @@ module Master
           pitch: style_config[:pitch],
           text: text.to_s
         )
-        UNIXSocket.open(TTS_SOCKET) do |s|
-          s.write("#{req}\n")
-          File.open(audio_path, "wb") { |f| IO.copy_stream(s, f) }
+        Timeout.timeout(worker_timeout) do
+          UNIXSocket.open(TTS_SOCKET) do |s|
+            s.write("#{req}\n")
+            File.open(audio_path, "wb") { |f| IO.copy_stream(s, f) }
+          end
         end
-        (File.exist?(audio_path) && File.size(audio_path) > 0) ? audio_path : nil
-      rescue StandardError
-        nil
+        return audio_path if File.exist?(audio_path) && File.size(audio_path) > 0
+
+        warn_tts("edge socket produced empty audio")
+        cleanup_failed_audio(audio_path)
+      rescue Timeout::Error
+        warn_tts("edge socket timed out after #{worker_timeout}s")
+        cleanup_failed_audio(audio_path)
+      rescue StandardError => e
+        warn_tts("edge socket failed: #{e.class}: #{e.message}")
+        cleanup_failed_audio(audio_path)
       end
 
       def synthesize_espeak(text)
         audio_path = "/tmp/m_tts_#{SecureRandom.hex(8)}.wav"
         ok = system(
-          ESPEAK, "-s", "162", "-p", "42", "-a", "125",
+          espeak_path, "-s", "162", "-p", "42", "-a", "125",
           "-w", audio_path, text.to_s,
           out: File::NULL, err: File::NULL
         )
-        (ok && File.exist?(audio_path) && File.size(audio_path) > 0) ? audio_path : nil
+        return audio_path if ok && File.exist?(audio_path) && File.size(audio_path) > 0
+
+        warn_tts("espeak failed or produced empty audio")
+        cleanup_failed_audio(audio_path)
+      rescue StandardError => e
+        warn_tts("espeak error: #{e.class}: #{e.message}")
+        cleanup_failed_audio(audio_path)
+      end
+
+      def cleanup_failed_audio(path)
+        File.unlink(path) rescue nil if path
+        nil
+      end
+
+      def worker_timeout
+        Integer(ENV.fetch("MASTER_TTS_TIMEOUT", WORKER_TIMEOUT.to_s))
+      rescue ArgumentError
+        WORKER_TIMEOUT
+      end
+
+      def warn_tts(message)
+        Kernel.warn("tts: #{message}")
       end
     end
   end

--- a/MASTER/test/test_speech.rb
+++ b/MASTER/test/test_speech.rb
@@ -7,6 +7,20 @@ class TestSpeech < Minitest::Test
     assert_includes [true, false], Master::Voice::Speech.available?
   end
 
+  def test_available_uses_real_backend_guards
+    Master::Voice::Speech.stub(:edge_tts_available?, false) do
+      Master::Voice::Speech.stub(:espeak_path, nil) do
+        refute Master::Voice::Speech.available?
+      end
+    end
+  end
+
+  def test_edge_tts_unavailable_without_worker
+    Master::Voice::Speech.stub(:worker_executable?, false) do
+      refute Master::Voice::Speech.edge_tts_available?
+    end
+  end
+
   def test_voices_constants_present
     assert Master::Voice::Speech::VOICES.key?(:osman)
     assert Master::Voice::Speech::VOICES.key?(:ryan)
@@ -59,6 +73,33 @@ class TestSpeech < Minitest::Test
       assert_equal "fake-mp3-data", bytes
       refute File.exist?(fake_path), "temp file should be deleted"
     end
+  end
+
+  def test_synthesize_falls_back_to_espeak_when_edge_returns_nil
+    Master::Voice::Speech.stub(:edge_tts_available?, true) do
+      Master::Voice::Speech.stub(:synthesize_edge, nil) do
+        Master::Voice::Speech.stub(:espeak_path, "/usr/local/bin/espeak") do
+          Master::Voice::Speech.stub(:synthesize_espeak, "/tmp/fallback.wav") do
+            assert_equal "/tmp/fallback.wav", Master::Voice::Speech.synthesize("hello")
+          end
+        end
+      end
+    end
+  end
+
+  def test_synthesize_edge_warns_and_cleans_up_failed_worker_output
+    status = Struct.new(:success?).new(false)
+    _out, err = capture_io do
+      ::Open3.stub(:capture3, ["", "worker failed", status]) do
+        assert_nil Master::Voice::Speech.synthesize_edge(
+          "hello",
+          voice: :ryan,
+          style_config: { rate: "+0%", pitch: "+0Hz" }
+        )
+      end
+    end
+
+    assert_includes err, "tts: edge worker failed: worker failed"
   end
 
   def test_unknown_voice_falls_back_to_default


### PR DESCRIPTION
## What changed

- Makes `Master::Voice::Speech.available?` check actual backend readiness instead of only checking whether `bin/tts-worker` exists.
- Adds EventMachine SSL preflight checks for Edge TTS, including daemon startup.
- Adds timeouts, stderr diagnostics, empty-audio cleanup, and eSpeak fallback handling for socket and subprocess paths.
- Adds focused speech tests for backend availability and Edge-to-eSpeak fallback behavior.

## Why

The TTS worker can be present and executable while Edge TTS is still unusable, especially when EventMachine lacks SSL support on OpenBSD. In that state, synthesis returned `nil` or empty output without a useful diagnostic and could leave callers thinking TTS was available.

## Validation

- `ruby -Itest test/test_speech.rb`
- `ruby -Ilib spec/voice/speech_contract_spec.rb`

A direct `bin/tts-worker` probe in the clean publish worktree was blocked before runtime by local Bundler state: missing `rake-13.4.2`, and `bundle install` stopped on an existing Gemfile.lock checksum mismatch for `dry-initializer`. The unit-level backend checks passed.
