### PR TITLE
Add MASTER business-plan validation gate

### DIFF
--- a/DEPLOY/bp/MASTER_COMMANDS.md
+++ b/DEPLOY/bp/MASTER_COMMANDS.md
@@ -1,0 +1,66 @@
+# MASTER commands for business plans
+
+This directory follows the MASTER rule: preserve, validate, then improve.
+
+Each idea gets one standalone HTML document. A business plan is valid only when it has inline CSS in a `<style>` tag, inline JavaScript in a `<script>` tag, no external stylesheet link, no external `script src`, Norwegian language markup, and all required Innovation Norway sections.
+
+## Commands
+
+Run the deterministic generator:
+
+```zsh
+ruby DEPLOY/bp/generate.rb
+```
+
+Run the BP gate:
+
+```zsh
+ruby DEPLOY/bp/master_bp_gate.rb
+```
+
+Run the repository scan through MASTER when available:
+
+```zsh
+cd MASTER
+bundle exec ruby bin/cli
+# /scan ../DEPLOY/bp --depth deep
+```
+
+On the OpenBSD VPS, use package-qualified Ruby when needed:
+
+```zsh
+ruby34 DEPLOY/bp/master_bp_gate.rb
+cd MASTER && bundle34 exec ruby bin/cli
+# /scan ../DEPLOY/bp --depth deep
+```
+
+## Required plan files
+
+- `syre.html`
+- `speis.html`
+- `norwegianhedge.html`
+- `pubhealthcare.html`
+- `ragnhild.html`
+- `govt_bergen.html`
+- `nato.html`
+- `ai3.html`
+
+## Required section ids
+
+- `sammendrag`
+- `problem-og-mulighet`
+- `marked-og-kunder`
+- `losning-og-produkt`
+- `teknologi-og-innovasjon`
+- `forretningsmodell`
+- `gjennomforing-og-drift`
+- `utviklingsveikart`
+- `finansieringsbehov`
+- `team-og-kompetanse`
+- `risiko-og-tiltak`
+- `baerekraft-og-samfunnsansvar`
+- `maltall-og-validering`
+
+## Merge rule
+
+Do not overwrite hand-written value blindly. If a section already exists in an HTML plan, preserve it unless the replacement is demonstrably more complete, more accurate, and still Norwegian.

--- a/DEPLOY/bp/master_bp_gate.rb
+++ b/DEPLOY/bp/master_bp_gate.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+ROOT = Pathname(__dir__)
+PLAN_FILES = %w[
+  syre.html
+  speis.html
+  norwegianhedge.html
+  pubhealthcare.html
+  ragnhild.html
+  govt_bergen.html
+  nato.html
+  ai3.html
+].freeze
+
+REQUIRED_SECTION_IDS = %w[
+  sammendrag
+  problem-og-mulighet
+  marked-og-kunder
+  losning-og-produkt
+  teknologi-og-innovasjon
+  forretningsmodell
+  gjennomforing-og-drift
+  utviklingsveikart
+  finansieringsbehov
+  team-og-kompetanse
+  risiko-og-tiltak
+  baerekraft-og-samfunnsansvar
+  maltall-og-validering
+].freeze
+
+class BusinessPlanGate
+  def initialize(root: ROOT)
+    @root = root
+  end
+
+  def run
+    findings = PLAN_FILES.flat_map { |file| inspect_plan(file) }
+    inspect_index(findings)
+    if findings.empty?
+      puts "bp_gate: ok files=#{PLAN_FILES.length}"
+      return true
+    end
+
+    findings.each { |finding| warn(finding) }
+    false
+  end
+
+  private
+
+  attr_reader :root
+
+  def inspect_plan(file)
+    path = root.join(file)
+    return ["#{file}: missing"] unless path.file?
+
+    html = path.read
+    findings = []
+    findings << "#{file}: missing inline <style>" unless html.include?("<style>")
+    findings << "#{file}: missing inline <script>" unless html.include?("<script>")
+    findings << "#{file}: external stylesheet link" if html.match?(/<link\b[^>]*rel=[\"']stylesheet/i)
+    findings << "#{file}: external script src" if html.match?(/<script\b[^>]*\bsrc=/i)
+    findings << "#{file}: language must be Norwegian" unless html.include?("lang=\"no\"") || html.include?("lang='no'")
+    findings.concat(missing_sections(file, html))
+    findings
+  end
+
+  def missing_sections(file, html)
+    REQUIRED_SECTION_IDS.filter_map do |section_id|
+      next if html.include?(%(<section id="#{section_id}")) || html.include?(%(<section id='#{section_id}'))
+
+      "#{file}: missing section ##{section_id}"
+    end
+  end
+
+  def inspect_index(findings)
+    path = root.join("index.html")
+    if !path.file?
+      findings << "index.html: missing"
+      return
+    end
+
+    html = path.read
+    PLAN_FILES.each do |file|
+      findings << "index.html: missing link to #{file}" unless html.include?(file)
+    end
+  end
+end
+
+exit(BusinessPlanGate.new.run ? 0 : 1)


### PR DESCRIPTION
Adds a MASTER-facing validation surface for DEPLOY/bp business plans.

What this PR adds:

- `DEPLOY/bp/master_bp_gate.rb`
- `DEPLOY/bp/MASTER_COMMANDS.md`

Rules enforced by the BP gate:

- one standalone HTML document per idea
- inline `<style>` required
- inline `<script>` required
- no external stylesheet link
- no external `script src`
- Norwegian `lang="no"`
- required Innovation Norway section ids present
- index links to all eight plan files

Commands:

```zsh
ruby DEPLOY/bp/master_bp_gate.rb
ruby DEPLOY/bp/generate.rb
cd MASTER && bundle exec ruby bin/cli
# /scan ../DEPLOY/bp --depth deep
```

The full generated Norwegian plan payload is prepared separately as `pub4_bp_full_norwegian_plans.patch` and `pub4_bp_full_norwegian_plans.zip`. Connector limitation: the GitHub write tool in this session could not ingest the full 260 KB generated HTML/YAML payload from `/mnt/data` directly, so this PR lands the MASTER command/gate layer first and leaves the generated plan patch as the next apply step.